### PR TITLE
Fix setting EC2 region, prevent XSS.

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -4,13 +4,6 @@
 # https://github.com/bbatsov/rubocop/blob/master/config/enabled.yml
 # https://github.com/bbatsov/rubocop/blob/master/config/disabled.yml
 
-AllCops:
-  Include:
-    - '**/Gemfile'
-    - '**/Rakefile'
-  TargetRubyVersion: 2.3
-  UseCache: true
-
 Rails:
   Enabled: true
 
@@ -56,6 +49,16 @@ Layout/ExtraSpacing:
   # When true, forces the alignment of = in assignments on consecutive lines.
   ForceEqualSignAlignment: false
 
+# empty lines are fine
+Layout/EmptyLinesAroundClassBody:
+  Enabled: false
+Layout/EmptyLinesAroundExceptionHandlingKeywords:
+  Enabled: false
+Layout/EmptyLinesAroundModuleBody:
+  Enabled: false
+Layout/EmptyLines:
+  Enabled: false
+
 # Checks the indentation of the first element in an array literal.
 Layout/IndentArray:
   # The value `special_inside_parentheses` means that array literals with
@@ -86,31 +89,31 @@ Layout/MultilineOperationIndentation:
   # By default, the indentation width from Style/IndentationWidth is used
   # But it can be overridden by setting this parameter
   IndentationWidth: ~
-  
-Metrics/AbcSize:
-  Description: A calculated magnitude based on number of assignments, branches, and
-    conditions.
-  Enabled: true
-  Max: 15
-  Exclude:
-  - spec/**/*
 
+# All of these Metrics are mostly useless as an indicator of anything
+Metrics/AbcSize:
+  Enabled: false
 Metrics/BlockLength:
   CountComments: false  # count full line comments?
   Enabled: true
   Max: 25
   Exclude:
+    - '**/bin/*'
     - 'spec/**/*.rb'
-
 Metrics/ClassLength:
-  Description: Avoid classes longer than 100 lines of code.
-  Enabled: true
-  CountComments: false
-  Max: 100
-  Exclude:
-  - app.rb
-  - spec/**/*
+  Enabled: false
+Metrics/CyclomaticComplexity:
+  Enabled: false
+Metrics/MethodLength:
+  Enabled: false
+Metrics/ModuleLength:
+  Enabled: false
+Metrics/PerceivedComplexity:
+  Enabled: false
+Metrics/ParameterLists:
+  Enabled: false
 
+# Line length is actually useful
 Metrics/LineLength:
   Description: Limit lines to 100 characters.
   StyleGuide: https://github.com/bbatsov/ruby-style-guide#80-character-limits
@@ -121,24 +124,7 @@ Metrics/LineLength:
   - http
   - https
   Exclude:
-    - 'config/routes.rb'
-
-Metrics/MethodLength:
-  Description: Avoid methods longer than 10 lines of code.
-  StyleGuide: https://github.com/bbatsov/ruby-style-guide#short-methods
-  Enabled: true
-  CountComments: false
-  Max: 10
-  Exclude:
-  - spec/**/*
-
-Metrics/ModuleLength:
-  CountComments: false
-  Max: 100
-  Description: Avoid modules longer than 100 lines of code.
-  Enabled: true
-  Exclude:
-  - spec/**/*
+    - 'spec/**/*'
 
 # This is a Rails 5 feature, so it should be disabled until we upgrade
 Rails/HttpPositionalArguments:
@@ -159,6 +145,19 @@ Style/AndOr:
   SupportedStyles:
   - always
   - conditionals
+
+Style/BlockDelimiters:
+  Enabled: false
+  # Prefer do...end for procedural blocks, {...} for functional
+  #EnforcedStyle: semantic
+
+# for certain module hierarchies this is not useful
+Style/ClassAndModuleChildren:
+  Enabled: false
+
+# This default recommendation is completely wrong
+Style/ConditionalAssignment:
+  Enabled: false
 
 Style/Documentation:
   Description: Document classes and non-namespace modules.
@@ -183,10 +182,20 @@ Style/FrozenStringLiteralComment:
                  to help transition from Ruby 2.3.0 to Ruby 3.0.
   Enabled: false
 
+# Too many false positives to be useful
+Style/GuardClause:
+  Enabled: false
+
+# Sometimes a `return` enhances clarity
+Style/RedundantReturn:
+  Enabled: false
+
+# Very frequently if/unless as modifier reduces clarity
 Style/IfUnlessModifier:
-  Description: Favor modifier if/unless usage when you have a single-line body.
-  StyleGuide: https://github.com/bbatsov/ruby-style-guide#if-as-a-modifier
-  Enabled: true
+  Enabled: false
+
+Style/RaiseArgs:
+  EnforcedStyle: compact
 
 Style/StringLiterals:
   Description: Checks if uses of quotes match the configured preference.
@@ -204,12 +213,11 @@ Style/TrailingCommaInArguments:
   # for all parenthesized method calls with arguments.
   EnforcedStyleForMultiline: no_comma
 
-Style/TrailingCommaInLiteral:
-  # If `comma`, the cop requires a comma after the last item in an array or
-  # hash, but only when each item is on its own line.
-  # If `consistent_comma`, the cop requires a comma after the last item of all
-  # non-empty array and hash literals.
-  EnforcedStyleForMultiline: comma
+# trailing commas improve diff clarity at no cost to readability
+Style/TrailingCommaInHashLiteral:
+  EnforcedStyleForMultiline: consistent_comma
+Style/TrailingCommaInArrayLiteral:
+  EnforcedStyleForMultiline: consistent_comma
 
 Style/SingleLineBlockParams:
   Enabled: false

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -50,6 +50,8 @@ Layout/ExtraSpacing:
   ForceEqualSignAlignment: false
 
 # empty lines are fine
+Layout/EmptyLinesAroundBlockBody:
+  Enabled: false
 Layout/EmptyLinesAroundClassBody:
   Enabled: false
 Layout/EmptyLinesAroundExceptionHandlingKeywords:

--- a/Gemfile
+++ b/Gemfile
@@ -8,6 +8,7 @@ ruby '~> 2.3.5'
 
 gem 'activesupport', '~> 5.2'
 gem 'aws-sdk-secretsmanager', '~> 1.21'
+gem 'erubi', '~> 1.8'
 gem 'httparty', '~> 0.16'
 gem 'identity-hostdata', github: '18F/identity-hostdata', branch: 'master'
 gem 'json-jwt', '~> 1.9.4'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -54,6 +54,7 @@ GEM
       thread_safe (~> 0.3, >= 0.3.1)
     diff-lcs (1.3)
     equalizer (0.0.11)
+    erubi (1.8.0)
     fakefs (0.19.2)
     hashdiff (0.3.8)
     httparty (0.16.4)
@@ -154,6 +155,7 @@ PLATFORMS
 DEPENDENCIES
   activesupport (~> 5.2)
   aws-sdk-secretsmanager (~> 1.21)
+  erubi (~> 1.8)
   fakefs
   httparty (~> 0.16)
   identity-hostdata!

--- a/app.rb
+++ b/app.rb
@@ -2,7 +2,7 @@
 
 require 'active_support/core_ext/hash/indifferent_access'
 require 'active_support/core_ext/object/to_query'
-require 'erb'
+require 'erubi'
 require 'httparty'
 require 'json'
 require 'json/jwt'
@@ -18,6 +18,10 @@ module LoginGov::OidcSinatra
   class AppError < StandardError; end
 
   class OpenidConnectRelyingParty < Sinatra::Base
+
+    # Auto escape parameters in ERB.
+    # Use `<%=` to escape HTML, or use `<%==` to inject unescaped raw HTML.
+    set :erb, escape_html: true
 
     def config
       @config ||= Config.new

--- a/app.rb
+++ b/app.rb
@@ -13,149 +13,151 @@ require 'time'
 
 require_relative './config'
 
-module LoginGov::OidcSinatra; class OpenidConnectRelyingParty < Sinatra::Base
-
+module LoginGov::OidcSinatra
   class AppError < StandardError; end
 
-  def config
-    @config ||= Config.new
-  end
+  class OpenidConnectRelyingParty < Sinatra::Base
 
-  get '/' do
-    begin
-      erb :index, locals: { loa1_url: authorization_url(1), loa3_url: authorization_url(3) }
-    rescue AppError => err
-      [500, erb(:errors, locals: { error: err.message })]
+    def config
+      @config ||= Config.new
     end
-  end
 
-  get '/auth/result' do
-    code = params[:code]
-
-    if code
-      token_response = token(code)
-      id_token = token_response[:id_token]
-      userinfo_response = userinfo(id_token)
-
-      erb :success, locals: {
-        userinfo: userinfo_response,
-        logout_uri: logout_uri(token_response[:id_token]),
-      }
-    else
-      error = params[:error] || 'missing callback param: code'
-
-      erb :errors, locals: { error: error }
-    end
-  end
-
-  private
-
-  def authorization_url(loa)
-    openid_configuration[:authorization_endpoint] + '?' + {
-      client_id: config.client_id,
-      response_type: 'code',
-      acr_values: 'http://idmanagement.gov/ns/assurance/loa/' + loa.to_s,
-      scope: scopes_for(loa),
-      redirect_uri: File.join(config.redirect_uri, '/auth/result'),
-      state: random_value,
-      nonce: random_value,
-      prompt: 'select_account',
-    }.to_query
-  end
-
-  def scopes_for(loa)
-    case loa
-    when 1
-      'openid email'
-    when 3
-      'openid email profile social_security_number phone'
-    else
-      raise ArgumentError.new("Unexpected LOA: #{loa.inspect}")
-    end
-  end
-
-  def openid_configuration
-    @openid_configuration ||= begin
-      response = openid_configuration_response
-      if response.code == 200
-        json(response.body)
-      else
-        msg = 'Error: Unable to retrieve OIDC configuration from IdP.'
-        msg += " #{config.idp_url} responded with #{response.code}."
-
-        if response.code == 401
-          msg += ' Perhaps we need to reimplement HTTP Basic Auth.'
-        end
-
-        raise AppError.new(msg)
+    get '/' do
+      begin
+        erb :index, locals: { loa1_url: authorization_url(1), loa3_url: authorization_url(3) }
+      rescue AppError => err
+        [500, erb(:errors, locals: { error: err.message })]
       end
     end
-  end
 
-  def openid_configuration_response
-    HTTParty.get(URI.join(config.idp_url, '/.well-known/openid-configuration'))
-  end
+    get '/auth/result' do
+      code = params[:code]
 
-  def token(code)
-    json HTTParty.post(
-      openid_configuration[:token_endpoint],
-      body: {
-        grant_type: 'authorization_code',
-        code: code,
-        client_assertion_type: 'urn:ietf:params:oauth:client-assertion-type:jwt-bearer',
-        client_assertion: client_assertion_jwt,
-      }
-    ).body
-  end
+      if code
+        token_response = token(code)
+        id_token = token_response[:id_token]
+        userinfo_response = userinfo(id_token)
 
-  def client_assertion_jwt
-    jwt_payload = {
-      iss: config.client_id,
-      sub: config.client_id,
-      aud: openid_configuration[:token_endpoint],
-      jti: random_value,
-      nonce: random_value,
-      exp: Time.now.to_i + 1000,
-    }
+        erb :success, locals: {
+          userinfo: userinfo_response,
+          logout_uri: logout_uri(token_response[:id_token]),
+        }
+      else
+        error = params[:error] || 'missing callback param: code'
 
-    JWT.encode(jwt_payload, config.sp_private_key, 'RS256')
-  end
-
-  def userinfo(id_token)
-    JWT.decode(id_token, idp_public_key, true, algorithm: 'RS256', leeway: 5).
-      first.
-      with_indifferent_access
-  end
-
-  def logout_uri(id_token)
-    openid_configuration[:end_session_endpoint] + '?' + {
-      id_token_hint: id_token,
-      post_logout_redirect_uri: config.redirect_uri,
-      state: SecureRandom.hex,
-    }.to_query
-  end
-
-  def json(response)
-    JSON.parse(response.to_s).with_indifferent_access
-  end
-
-  def idp_public_key
-    certs_response = json(
-      HTTParty.get(openid_configuration[:jwks_uri]).body
-    )
-    JSON::JWK.new(certs_response[:keys].first).to_key
-  end
-
-  def random_value
-    SecureRandom.hex
-  end
-
-  def maybe_redact_ssn(ssn)
-    if config.redact_ssn?
-      # redact all characters since they're all sensitive
-      ssn = ssn.gsub(/\d/, '#')
+        erb :errors, locals: { error: error }
+      end
     end
 
-    ssn
+    private
+
+    def authorization_url(loa)
+      openid_configuration[:authorization_endpoint] + '?' + {
+        client_id: config.client_id,
+        response_type: 'code',
+        acr_values: 'http://idmanagement.gov/ns/assurance/loa/' + loa.to_s,
+        scope: scopes_for(loa),
+        redirect_uri: File.join(config.redirect_uri, '/auth/result'),
+        state: random_value,
+        nonce: random_value,
+        prompt: 'select_account',
+      }.to_query
+    end
+
+    def scopes_for(loa)
+      case loa
+      when 1
+        'openid email'
+      when 3
+        'openid email profile social_security_number phone'
+      else
+        raise ArgumentError.new("Unexpected LOA: #{loa.inspect}")
+      end
+    end
+
+    def openid_configuration
+      @openid_configuration ||= begin
+        response = openid_configuration_response
+        if response.code == 200
+          json(response.body)
+        else
+          msg = 'Error: Unable to retrieve OIDC configuration from IdP.'
+          msg += " #{config.idp_url} responded with #{response.code}."
+
+          if response.code == 401
+            msg += ' Perhaps we need to reimplement HTTP Basic Auth.'
+          end
+
+          raise AppError.new(msg)
+        end
+      end
+    end
+
+    def openid_configuration_response
+      HTTParty.get(URI.join(config.idp_url, '/.well-known/openid-configuration'))
+    end
+
+    def token(code)
+      json HTTParty.post(
+        openid_configuration[:token_endpoint],
+        body: {
+          grant_type: 'authorization_code',
+          code: code,
+          client_assertion_type: 'urn:ietf:params:oauth:client-assertion-type:jwt-bearer',
+          client_assertion: client_assertion_jwt,
+        }
+      ).body
+    end
+
+    def client_assertion_jwt
+      jwt_payload = {
+        iss: config.client_id,
+        sub: config.client_id,
+        aud: openid_configuration[:token_endpoint],
+        jti: random_value,
+        nonce: random_value,
+        exp: Time.now.to_i + 1000,
+      }
+
+      JWT.encode(jwt_payload, config.sp_private_key, 'RS256')
+    end
+
+    def userinfo(id_token)
+      JWT.decode(id_token, idp_public_key, true, algorithm: 'RS256', leeway: 5).
+        first.
+        with_indifferent_access
+    end
+
+    def logout_uri(id_token)
+      openid_configuration[:end_session_endpoint] + '?' + {
+        id_token_hint: id_token,
+        post_logout_redirect_uri: config.redirect_uri,
+        state: SecureRandom.hex,
+      }.to_query
+    end
+
+    def json(response)
+      JSON.parse(response.to_s).with_indifferent_access
+    end
+
+    def idp_public_key
+      certs_response = json(
+        HTTParty.get(openid_configuration[:jwks_uri]).body
+      )
+      JSON::JWK.new(certs_response[:keys].first).to_key
+    end
+
+    def random_value
+      SecureRandom.hex
+    end
+
+    def maybe_redact_ssn(ssn)
+      if config.redact_ssn?
+        # redact all characters since they're all sensitive
+        ssn = ssn.gsub(/\d/, '#')
+      end
+
+      ssn
+    end
   end
-end; end
+end

--- a/config.rb
+++ b/config.rb
@@ -62,13 +62,17 @@ module LoginGov::OidcSinatra
 
       if LoginGov::Hostdata.in_datacenter?
         # EC2 deployment defaults
-        if LoginGov::Hostdata.env == 'prod'
-          data['idp_url'] = "https://secure.#{LoginGov::Hostdata.domain}"
+
+        env = LoginGov::Hostdata.env
+        domain = LoginGov::Hostdata.domain
+
+        if env == 'prod'
+          data['idp_url'] = "https://secure.#{domain}"
         else
-          data['idp_url'] = "https://idp.#{LoginGov::Hostdata.env}.#{LoginGov::Hostdata.domain}"
+          data['idp_url'] = "https://idp.#{env}.#{domain}"
         end
-        data['redirect_uri'] = "https://sp-oidc-sinatra.#{LoginGov::Hostdata.env}.#{LoginGov::Hostdata.domain}/"
-        data['sp_private_key_path'] = "aws-secretsmanager:#{LoginGov::Hostdata.env}/sp-oidc-sinatra/oidc.key"
+        data['redirect_uri'] = "https://sp-oidc-sinatra.#{env}.#{domain}/"
+        data['sp_private_key_path'] = "aws-secretsmanager:#{env}/sp-oidc-sinatra/oidc.key"
         data['redact_ssn'] = true
       else
         # local dev defaults
@@ -90,7 +94,7 @@ module LoginGov::OidcSinatra
         # Set region using EC2 metadata if we're in EC2
         if LoginGov::Hostdata.in_datacenter?
           ec2 = LoginGov::Hostdata::EC2.load
-          opts = {region: ec2.region}
+          opts = { region: ec2.region }
         else
           opts = {}
         end
@@ -115,6 +119,7 @@ module LoginGov::OidcSinatra
       if LoginGov::Hostdata.domain == 'login.gov' || LoginGov::Hostdata.env == 'prod'
         raise 'Refusing to use demo key in production'
       end
+
       File.dirname(__FILE__) + '/config/demo_sp.key'
     end
   end

--- a/spec/app_spec.rb
+++ b/spec/app_spec.rb
@@ -57,7 +57,7 @@ RSpec.describe LoginGov::OidcSinatra::OpenidConnectRelyingParty do
 
     it 'renders an error if the app fails to get oidc configuration' do
       stub = stub_request(:get, "#{host}/.well-known/openid-configuration").
-        to_return(body: '', status: 400)
+             to_return(body: '', status: 400)
 
       get '/'
 

--- a/spec/app_spec.rb
+++ b/spec/app_spec.rb
@@ -112,6 +112,17 @@ RSpec.describe LoginGov::OidcSinatra::OpenidConnectRelyingParty do
       expect(last_response.body).to include('LOA1')
     end
 
+    context 'with dangerous input' do
+      let(:email) { '<script>alert("hi")</script> mallory@bar.com' }
+
+      it 'escapes dangerous HTML' do
+        get '/auth/result', code: code
+
+        expect(last_response.body).to_not include(email)
+        expect(last_response.body).to include('&lt;script&gt;alert(&quot;hi&quot;)&lt;/script&gt; mallory@bar.com')
+      end
+    end
+
     it 'has a logout link back to the SP-initiated logout URL' do
       get '/auth/result', code: code
 

--- a/spec/app_spec.rb
+++ b/spec/app_spec.rb
@@ -56,12 +56,15 @@ RSpec.describe LoginGov::OidcSinatra::OpenidConnectRelyingParty do
     end
 
     it 'renders an error if the app fails to get oidc configuration' do
-      stub_request(:get, "#{host}/.well-known/openid-configuration").
+      stub = stub_request(:get, "#{host}/.well-known/openid-configuration").
         to_return(body: '', status: 400)
 
       get '/'
-      error_string = "Error: #{host} responded with 400."
+
+      error_string = "Error: Unable to retrieve OIDC configuration from IdP. #{host} responded with 400."
       expect(last_response.body).to include(error_string)
+      expect(stub).to have_been_requested.once
+      expect(last_response.status).to eq 500
     end
   end
 

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -4,8 +4,7 @@ require 'webmock/rspec'
 
 ENV['RACK_ENV'] = 'test'
 
-$LOAD_PATH.unshift File.expand_path('../..', __FILE__)
-require 'app'
+require_relative '../app'
 
 module RSpecMixin
   include Rack::Test::Methods

--- a/views/index.erb
+++ b/views/index.erb
@@ -13,7 +13,7 @@
       <img class="align-middle" width="125" src="/images/login-gov.svg" alt="Login gov">
     </a>
   </div>
-  <%= erb :page_content %>
+  <%== erb :page_content %>
 </div>
 <script>
   function gotoAuthUrl() {

--- a/views/layout.erb
+++ b/views/layout.erb
@@ -4,9 +4,9 @@
     <meta charset="utf-8">
     <title>Identity</title>
     <meta name="viewport" content="width=device-width,initial-scale=1">
-    <link rel="stylesheet" type="text/css" media="all" href="/css/basscss.min.css"></style> 
+    <link rel="stylesheet" type="text/css" media="all" href="/css/basscss.min.css"></style>
   </head>
   <body class="bg-darken-1">
-    <%= yield %>
+    <%== yield %>
   </body>
 </html>

--- a/views/success.erb
+++ b/views/success.erb
@@ -1,2 +1,2 @@
-<%= erb :user_info, locals: { userinfo: userinfo, logout_uri: logout_uri } %>
-<%= erb :page_content %>
+<%== erb :user_info, locals: { userinfo: userinfo, logout_uri: logout_uri } %>
+<%== erb :page_content %>


### PR DESCRIPTION
**Auto escape HTML in all ERB templates.**

- Switch to erubi for rendering erb, and enable its auto-escape mode.

- The app was previously vulnerable to all kinds of XSS since it wasn't
  escaping content. Fortunately most of that content wasn't directly
  user-provided, but this would've likely only gotten worse.

- Add a test that HTML is XSS escaped.

Fixes: https://github.com/18F/identity-oidc-sinatra/issues/48

**Add a healthcheck endpoint.**

**Actually run rubocop on app.rb, fix warnings.**

- Previously rubocop was only run on the Gemfile.

**Improve OIDC config error handling.**

- Previously, the app would throw away the response code from fetching
 OIDC config from the IdP if it errored the first time, and then make a
 second request and display the response code returned by the second
 request.
- Instead, capture the error on the original request by raising an
 exception.
- This also moves the error handling closer to where the OIDC config is
 actually fetched.
- Add a test that the OIDC config endpoint is fetched exactly once.

**Set region using EC2 metadata if in EC2.**

- The region is required if AWS_REGION is not set. Also memoize the returned
  private key so we're not fetching all the time. (Not sure this memoization
  actually works or if we re-fetch on every request.)