### PR TITLE
Fix app to handle SSN not provided at LOA3.

### DIFF
--- a/app.rb
+++ b/app.rb
@@ -177,7 +177,7 @@ module LoginGov::OidcSinatra
     def maybe_redact_ssn(ssn)
       if config.redact_ssn?
         # redact all characters since they're all sensitive
-        ssn = ssn.gsub(/\d/, '#')
+        ssn = ssn&.gsub(/\d/, '#')
       end
 
       ssn


### PR DESCRIPTION
This fixes a nil NoMethodError if the SSN was not requested and redaction is
enabled.