### PR TITLE
LG-1422: successful login returns to home page

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -28,3 +28,7 @@ group :test do
   gem 'rspec', '~> 3.5.0'
   gem 'webmock'
 end
+
+group :development, :test do
+  gem 'byebug'
+end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -155,6 +155,7 @@ PLATFORMS
 DEPENDENCIES
   activesupport (~> 5.2)
   aws-sdk-secretsmanager (~> 1.21)
+  byebug
   erubi (~> 1.8)
   fakefs
   httparty (~> 0.16)
@@ -174,4 +175,4 @@ RUBY VERSION
    ruby 2.3.5p376
 
 BUNDLED WITH
-   1.17.1
+   1.17.3

--- a/app.rb
+++ b/app.rb
@@ -2,6 +2,7 @@
 
 require 'active_support/core_ext/hash/indifferent_access'
 require 'active_support/core_ext/object/to_query'
+require 'byebug'
 require 'erubi'
 require 'httparty'
 require 'json'
@@ -23,15 +24,30 @@ module LoginGov::OidcSinatra
     # Use `<%=` to escape HTML, or use `<%==` to inject unescaped raw HTML.
     set :erb, escape_html: true
 
+    enable :sessions
+
     def config
       @config ||= Config.new
     end
 
     get '/' do
       begin
-        erb :index, locals: { ial_url: ial_url,
-                              ial1_link_class: ial1_link_class,
-                              ial2_link_class: ial2_link_class }
+        login_msg = session.delete(:login_msg)
+        logout_msg = session.delete(:logout_msg)
+        user_email = session[:email]
+        logout_uri = session[:logout_uri]
+        userinfo = session.delete(:userinfo)
+
+        erb :index, locals: {
+          ial_url: ial_url,
+          ial1_link_class: ial1_link_class,
+          ial2_link_class: ial2_link_class,
+          login_msg: login_msg,
+          logout_msg: logout_msg,
+          user_email: user_email,
+          logout_uri: logout_uri,
+          userinfo: userinfo,
+        }
       rescue AppError => err
         [500, erb(:errors, locals: { error: err.message })]
       rescue Errno::ECONNREFUSED => err
@@ -47,15 +63,25 @@ module LoginGov::OidcSinatra
         id_token = token_response[:id_token]
         userinfo_response = userinfo(id_token)
 
-        erb :success, locals: {
-          userinfo: userinfo_response,
-          logout_uri: logout_uri(token_response[:id_token]),
-        }
+        session[:login_msg] = 'ok'
+        session[:logout_uri] = logout_uri(token_response[:id_token])
+        session[:userinfo] = userinfo_response
+        session[:email] = session[:userinfo][:email]
+
+        redirect to('/')
       else
         error = params[:error] || 'missing callback param: code'
 
         erb :errors, locals: { error: error }
       end
+    end
+
+    get '/logout' do
+      session[:logout_msg] = 'ok'
+      session.delete(:logout_uri)
+      session.delete(:userinfo)
+      session.delete(:email)
+      redirect to('/')
     end
 
     get '/api/health' do
@@ -156,7 +182,7 @@ module LoginGov::OidcSinatra
     def logout_uri(id_token)
       openid_configuration[:end_session_endpoint] + '?' + {
         id_token_hint: id_token,
-        post_logout_redirect_uri: config.redirect_uri,
+        post_logout_redirect_uri: File.join(config.redirect_uri, 'logout'),
         state: SecureRandom.hex,
       }.to_query
     end
@@ -187,16 +213,19 @@ module LoginGov::OidcSinatra
 
     def ial_url
       return authorization_url(3) if params[:ial] == '2'
+
       authorization_url(1)
     end
 
     def ial1_link_class
       return 'text-underline' unless params[:ial] == '2'
+
       nil
     end
 
     def ial2_link_class
       return 'text-underline' if params[:ial] == '2'
+
       nil
     end
   end

--- a/config.rb
+++ b/config.rb
@@ -16,7 +16,7 @@ module LoginGov::OidcSinatra
       config_file ||= File.dirname(__FILE__) + '/config/application.yml'
 
       if File.exist?(config_file)
-        STDERR.puts("Loading config from #{config_file.inspect}")
+        # STDERR.puts("Loading config from #{config_file.inspect}")
         @config.merge!(YAML.safe_load(File.read(config_file)))
       end
     end

--- a/public/assets/css/fake.css
+++ b/public/assets/css/fake.css
@@ -27,3 +27,18 @@
   padding-top: 0.5rem;
   padding-bottom: 0.5rem;
 }
+
+.p2 {
+  padding: 1rem;
+}
+
+.userinfo {
+  top: 100px;
+  right: 40px;
+}
+.userinfo pre {
+  margin: 0;
+}
+.fright {
+  float: right;
+}

--- a/spec/app_spec.rb
+++ b/spec/app_spec.rb
@@ -138,8 +138,11 @@ RSpec.describe LoginGov::OidcSinatra::OpenidConnectRelyingParty do
     it 'takes an authorization code and gets a token, and renders the email from the token' do
       get '/auth/result', code: code
 
+      expect(last_response).to be_redirect
+      follow_redirect!
       expect(last_response.body).to include(email)
-      expect(last_response.body).to include('LOA1')
+      # expect(last_response.body).to include(email)
+      # expect(last_response.body).to include('LOA1')
     end
 
     context 'with dangerous input' do
@@ -147,6 +150,7 @@ RSpec.describe LoginGov::OidcSinatra::OpenidConnectRelyingParty do
 
       it 'escapes dangerous HTML' do
         get '/auth/result', code: code
+        follow_redirect!
 
         expect(last_response.body).to_not include(email)
         expect(last_response.body).to include('&lt;script&gt;alert(&quot;hi&quot;)&lt;/script&gt; mallory@bar.com')
@@ -155,10 +159,10 @@ RSpec.describe LoginGov::OidcSinatra::OpenidConnectRelyingParty do
 
     it 'has a logout link back to the SP-initiated logout URL' do
       get '/auth/result', code: code
-
+      follow_redirect!
       doc = Nokogiri::HTML(last_response.body)
 
-      logout_link = doc.at_xpath("//a[text()='Log out']")
+      logout_link = doc.at_xpath("//div[@class='sign-in-wrap']/a[text()='\n              Log out\n            ']")
       expect(logout_link).to be
 
       href = logout_link[:href]
@@ -201,6 +205,7 @@ RSpec.describe LoginGov::OidcSinatra::OpenidConnectRelyingParty do
         expect_any_instance_of(LoginGov::OidcSinatra::Config).to receive(:redact_ssn?).at_least(:once).and_return(false)
 
         get '/auth/result', code: code
+        follow_redirect!
 
         expect(last_response.body).to include('012-34-5678')
         expect(last_response.body).to include('0125551212')
@@ -212,6 +217,7 @@ RSpec.describe LoginGov::OidcSinatra::OpenidConnectRelyingParty do
         expect_any_instance_of(LoginGov::OidcSinatra::Config).to receive(:redact_ssn?).at_least(:once).and_return(true)
 
         get '/auth/result', code: code
+        follow_redirect!
 
         expect(last_response.body).to_not include('012-34-5678')
         expect(last_response.body).to include('###-##-####')
@@ -238,6 +244,7 @@ RSpec.describe LoginGov::OidcSinatra::OpenidConnectRelyingParty do
         expect_any_instance_of(LoginGov::OidcSinatra::Config).to receive(:redact_ssn?).at_least(:once).and_return(true)
 
         get '/auth/result', code: code
+        follow_redirect!
 
         expect(last_response.body).to_not include('012-34-5678')
         expect(last_response.body).to_not include('###-##-####')

--- a/views/index.erb
+++ b/views/index.erb
@@ -125,9 +125,18 @@
   <section class="usa-hero">
     <div class="grid-container">
       <div class="usa-hero__callout">
-        <h1 class="usa-hero__heading"><span class="usa-hero__heading--alt">Get started:</span>It's easy to create your account
-        </h1><p>You can create your new account in just a few short minutes.</p>
-        <a class="usa-button" href="javascript:void(0);">Create an account</a>
+        <% if user_email %>
+          <h1 class="usa-hero__heading">
+            <span class="usa-hero__heading--alt">Welcome Back!</span>Wasn't it easy to log in?
+          </h1>
+          <p>You can log out by clicking the 'Log out' button above in the header.</p>
+        <% else %>
+          <h1 class="usa-hero__heading">
+            <span class="usa-hero__heading--alt">Get started:</span>It's easy to create your account
+          </h1>
+          <p>You can create your new account in just a few short minutes.</p>
+          <a class="usa-button" href="javascript:void(0);">Create an account</a>
+        <% end %>
       </div>
     </div>
   </section>

--- a/views/index.erb
+++ b/views/index.erb
@@ -8,57 +8,118 @@
 </div>
 <div class="usa-overlay"></div>
 <header class="usa-header usa-header--extended" role="banner">
-   <div class="usa-navbar">
-      <div class="usa-logo" id="extended-logo">
-         <em class="usa-logo__text"><a href="/" title="Home" aria-label="Home">OpenID Connect Example</a></em>
+  <% if logout_msg %>
+    <div class="clearfix">
+      <div class="col-12 sm-col-6 mx-auto">
+      <% if logout_msg == 'ok' %>
+        <div class="h5 p1 bg-green white center">
+          <span class="bold caps">You have been logged out.</span>
+        </div>
+      <% else %>
+        <div class="h5 p1 bg-red white center">
+          <span class="bold caps">Logout failed!</span>
+        </div>
+      <% end %>
       </div>
-      <button class="usa-menu-btn">Menu</button>
-   </div>
-   <nav role="navigation" class="usa-nav">
-      <div class="usa-nav__inner">
-         <button class="usa-nav__close"><img src="/assets/img/close.svg" alt="close"></button>
-         <ul class="usa-nav__primary usa-accordion">
-            <li class="usa-nav__primary-item">
-               <button class="usa-accordion__button usa-nav__link  usa-current" aria-expanded="false" aria-controls="extended-nav-section-one"><span>Our process</span></button>
-               <ul id="extended-nav-section-one" class="usa-nav__submenu">
-                  <li class="usa-nav__submenu-item">
-                     <a href="#">Navigation link</a>
-                  </li>
-                  <li class="usa-nav__submenu-item">
-                     <a href="#">Navigation link</a>
-                  </li>
-                  <li class="usa-nav__submenu-item">
-                     <a href="#">Navigation link</a>
-                  </li>
-               </ul>
+    </div>
+  <% end %>
+  <% if login_msg %>
+    <div class="clearfix">
+      <div class="col-12 sm-col-6 mx-auto">
+        <div class="h5 p1 bg-green white center">
+          <span class="bold caps">Login was a Success!</span>
+        </div>
+      </div>
+    </div>
+  <% end %>
+  <div class="usa-navbar">
+    <div class="usa-logo" id="extended-logo">
+       <em class="usa-logo__text"><a href="/" title="Home" aria-label="Home">OpenID Connect Example</a></em>
+    </div>
+    <button class="usa-menu-btn">Menu</button>
+  </div>
+  <nav role="navigation" class="usa-nav">
+    <div class="usa-nav__inner">
+      <button class="usa-nav__close"><img src="/assets/img/close.svg" alt="close"></button>
+      <ul class="usa-nav__primary usa-accordion">
+        <li class="usa-nav__primary-item">
+          <button class="usa-accordion__button usa-nav__link  usa-current" aria-expanded="false" aria-controls="extended-nav-section-one"><span>Our process</span></button>
+          <ul id="extended-nav-section-one" class="usa-nav__submenu">
+            <li class="usa-nav__submenu-item">
+               <a href="#">Navigation link</a>
             </li>
-            <li class="usa-nav__primary-item">
-               <a class="usa-nav__link" href="javascript:void(0)"><span>Explore</span></a>
+            <li class="usa-nav__submenu-item">
+               <a href="#">Navigation link</a>
             </li>
-            <li class="usa-nav__primary-item">
-               <a class="usa-nav__link" href="javascript:void(0)"><span>News</span></a>
+            <li class="usa-nav__submenu-item">
+               <a href="#">Navigation link</a>
             </li>
-         </ul>
-         <div class="usa-nav__secondary">
-            <ul class="usa-nav__secondary-links sign-in-type-wrap">
-               <li class="usa-nav__secondary-item">
-                  <a href="?ial=1"><span class="<%= ial1_link_class %>">IAL1</span></a>
-               </li>
-               <li class="usa-nav__secondary-item">
-                  <a href="?ial=2"><span class="<%= ial2_link_class %>">IAL2</span></a>
-               </li>
-            </ul>
-            <div class="sign-in-wrap">
-               <a class="usa-button usa-button--outline sign-in-bttn" href="<%= ial_url %>" style="float:right">
-                  <svg role="img" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 512 512">
-                     <path fill="currentColor" d="M416 448h-84c-6.6 0-12-5.4-12-12v-40c0-6.6 5.4-12 12-12h84c17.7 0 32-14.3 32-32V160c0-17.7-14.3-32-32-32h-84c-6.6 0-12-5.4-12-12V76c0-6.6 5.4-12 12-12h84c53 0 96 43 96 96v192c0 53-43 96-96 96zm-47-201L201 79c-15-15-41-4.5-41 17v96H24c-13.3 0-24 10.7-24 24v96c0 13.3 10.7 24 24 24h136v96c0 21.5 26 32 41 17l168-168c9.3-9.4 9.3-24.6 0-34z"></path>
-                  </svg>
-                  Sign in
-               </a>
+          </ul>
+        </li>
+        <li class="usa-nav__primary-item">
+          <a class="usa-nav__link" href="javascript:void(0)"><span>Explore</span></a>
+        </li>
+        <li class="usa-nav__primary-item">
+          <a class="usa-nav__link" href="javascript:void(0)"><span>News</span></a>
+        </li>
+      </ul>
+      <% if user_email %>
+        <div class="usa-nav__secondary">
+          <div class="fright"><%= user_email %></div>
+          <div class="sign-in-wrap">
+            <a class="usa-button usa-button--outline sign-in-bttn" href="<%= logout_uri %>">
+              <svg role="img" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 512 512">
+                <path fill="currentColor" d="M416 448h-84c-6.6 0-12-5.4-12-12v-40c0-6.6 5.4-12 12-12h84c17.7 0 32-14.3 32-32V160c0-17.7-14.3-32-32-32h-84c-6.6 0-12-5.4-12-12V76c0-6.6 5.4-12 12-12h84c53 0 96 43 96 96v192c0 53-43 96-96 96zm-47-201L201 79c-15-15-41-4.5-41 17v96H24c-13.3 0-24 10.7-24 24v96c0 13.3 10.7 24 24 24h136v96c0 21.5 26 32 41 17l168-168c9.3-9.4 9.3-24.6 0-34z"></path>
+              </svg>
+              Log out
+            </a>
+          </div>
+        </div>
+        <% if userinfo %>
+          <div class="usa-nav__secondary userinfo">
+            <div class="p2 clearfix bg-white">
+              <span>Received user info:</span>
+                <% case userinfo.fetch('acr')
+                     when 'http://idmanagement.gov/ns/assurance/loa/3' %>
+                  <span>Login type: <strong>LOA3</strong></span>
+                  <span class="ml1 mr1">|</span>
+                  <span>SSN: <strong><%= maybe_redact_ssn(userinfo[:social_security_number]) %></strong></span>
+                <% when 'http://idmanagement.gov/ns/assurance/loa/1' %>
+                  <span>Login type: <strong>LOA1</strong></span>
+                <% else %>
+                  <span>Login type: <strong>Unexpected ACR: <%= userinfo.fetch('acr') %></strong></span>
+                <% end %>
+              <ul>
+              <% userinfo.each_pair do |key, val| %>
+                <% val = maybe_redact_ssn(val) if key.to_s == 'social_security_number' %>
+                <li><pre><%= key.inspect %>: <%= val.inspect %></pre></li>
+              <% end %>
+              </ul>
             </div>
-         </div>
-      </div>
-   </nav>
+          </div>
+        <% end %>
+      <% else %>
+        <div class="usa-nav__secondary">
+          <ul class="usa-nav__secondary-links sign-in-type-wrap">
+            <li class="usa-nav__secondary-item">
+              <a href="?ial=1"><span class="<%= ial1_link_class %>">IAL1</span></a>
+            </li>
+            <li class="usa-nav__secondary-item">
+              <a href="?ial=2"><span class="<%= ial2_link_class %>">IAL2</span></a>
+            </li>
+          </ul>
+          <div class="sign-in-wrap">
+            <a class="usa-button usa-button--outline sign-in-bttn" href="<%= ial_url %>" style="float:right">
+              <svg role="img" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 512 512">
+                <path fill="currentColor" d="M416 448h-84c-6.6 0-12-5.4-12-12v-40c0-6.6 5.4-12 12-12h84c17.7 0 32-14.3 32-32V160c0-17.7-14.3-32-32-32h-84c-6.6 0-12-5.4-12-12V76c0-6.6 5.4-12 12-12h84c53 0 96 43 96 96v192c0 53-43 96-96 96zm-47-201L201 79c-15-15-41-4.5-41 17v96H24c-13.3 0-24 10.7-24 24v96c0 13.3 10.7 24 24 24h136v96c0 21.5 26 32 41 17l168-168c9.3-9.4 9.3-24.6 0-34z"></path>
+              </svg>
+              Sign in
+            </a>
+          </div>
+        </div>
+      <% end %>
+    </div>
+  </nav>
 </header>
 <main id="main-content">
   <section class="usa-hero">


### PR DESCRIPTION
As an agency partner looking at an example app, I want the success page to look like the demo app's main page, so that I do not think the demo site is broken.

Successful login/logout now returns to the home page.

Note: to continue showing the returned userinfo, they will display in an overlay div but, like the flash message, will disappear upon reloading the page.