### PR TITLE
LG-1906: redirect logs to /srv/sp-oidc-sinatra/shared/log/production.log

### DIFF
--- a/app.rb
+++ b/app.rb
@@ -29,6 +29,12 @@ module LoginGov::OidcSinatra
       require 'byebug'
     end
 
+    if LoginGov::Hostdata.in_datacenter?
+      logger = Logger.new(File.open("/srv/sp-oidc-sinatra/shared/log/production.log", 'a'))
+      logger.level = Logger::DEBUG
+      set :logger, logger
+    end
+
     def config
       @config ||= Config.new
     end

--- a/app.rb
+++ b/app.rb
@@ -30,9 +30,12 @@ module LoginGov::OidcSinatra
     end
 
     if LoginGov::Hostdata.in_datacenter?
-      logger = Logger.new(File.open("/srv/sp-oidc-sinatra/shared/log/production.log", 'a'))
-      logger.level = Logger::DEBUG
-      set :logger, logger
+      configure do
+        enable :logging
+        file = File.new("/srv/sp-oidc-sinatra/shared/log/production.log", 'a+')
+        file.sync = true
+        use Rack::CommonLogger, file
+      end
     end
 
     def config


### PR DESCRIPTION
A quick PR to get logs going to the correct log file so they show up in CloudWatch.