### PR TITLE
LG-2492: new rake task to generate deploy.json, called by CircleCI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -22,6 +22,7 @@ jobs:
             gem install bundler
             bundle install --deployment --jobs=4 --retry=3 --without deploy development doc production --path vendor/bundle
             cp .env.example .env
+            bundle exec rake login:deploy_json
 
       # Store bundle cache
       - save-cache:
@@ -56,6 +57,7 @@ jobs:
           command: |
             gem install bundler
             bundle install --deployment --jobs=4 --retry=3 --without deploy development doc production --path vendor/bundle
+            bundle exec rake login:deploy_json
 
       - run:
           name: Install cf cli

--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,4 @@
 .byebug_history
 /log
 .env
+public/api/deploy.json

--- a/Gemfile
+++ b/Gemfile
@@ -13,6 +13,7 @@ gem 'erubi', '~> 1.8'
 gem 'httparty', '~> 0.16'
 gem 'json-jwt', '~> 1.11.0'
 gem 'jwt', '~> 2.1'
+gem 'rake'
 gem 'sinatra', '~> 2.0', '>= 2.0.2'
 
 group :development do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -85,6 +85,7 @@ GEM
     rack-test (1.1.0)
       rack (>= 1.0, < 3)
     rainbow (3.0.0)
+    rake (13.0.1)
     reek (5.3.1)
       codeclimate-engine-rb (~> 0.4.0)
       kwalify (~> 0.7.0)
@@ -151,6 +152,7 @@ DEPENDENCIES
   nokogiri (~> 1.10)
   pry-byebug
   rack-test
+  rake
   reek
   rspec (~> 3.5.0)
   rubocop

--- a/Rakefile
+++ b/Rakefile
@@ -1,0 +1,2 @@
+require "./app"
+Dir.glob('lib/tasks/*.rake').each { |r| load r}

--- a/lib/tasks/write_deploy_json.rake
+++ b/lib/tasks/write_deploy_json.rake
@@ -1,0 +1,24 @@
+namespace :login do
+  desc 'generate a generic deploy.json file'
+  task :deploy_json do
+    puts 'Writing deploy.json'
+    data = {
+      env: ENV['environment'] || 'unkown',
+      branch: `git branch --no-color 2> /dev/null | sed -e '/^[^*]/d' -e 's/* \(.*\)/\1/'`.chomp[2..-1],
+      user: 'n/a',
+      git_sha: `git rev-parse HEAD`.chomp,
+      git_date: Time.at(`git show -s --format=%ct HEAD`.chomp.to_i).iso8601,
+      cloud_gov_deploy_timestamp: DateTime.now.strftime('%Y%m%d%H%M%S'),
+      fqdn: 'n/a',
+      instance_id: 'n/a',
+    }
+
+    # set deprecated attribute names
+    data[:sha] = data[:git_sha]
+    data[:timestamp] = data[:cloud_gov_deploy_timestamp]
+
+    File.open('public/api/deploy.json', 'w') do |f|
+      f.write(JSON.generate(data))
+    end
+  end
+end


### PR DESCRIPTION
Generate a deploy.json via CircleCI to allow the dashboard to show the git sha that is currently deployed.