### PR TITLE
Bring back glyph in sign in button

### DIFF
--- a/views/index.erb
+++ b/views/index.erb
@@ -79,7 +79,12 @@
         <form action="/auth/request">
           <div class="usa-nav__secondary">
             <div class="sign-in-wrap clearfix">
-              <input type="submit" class="usa-button usa-button--outline sign-in-bttn float-right" value="Sign in" />
+              <button type="submit" class="usa-button usa-button--outline sign-in-bttn float-right">
+                <svg role="img" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 512 512">
+                  <path fill="currentColor" d="M416 448h-84c-6.6 0-12-5.4-12-12v-40c0-6.6 5.4-12 12-12h84c17.7 0 32-14.3 32-32V160c0-17.7-14.3-32-32-32h-84c-6.6 0-12-5.4-12-12V76c0-6.6 5.4-12 12-12h84c53 0 96 43 96 96v192c0 53-43 96-96 96zm-47-201L201 79c-15-15-41-4.5-41 17v96H24c-13.3 0-24 10.7-24 24v96c0 13.3 10.7 24 24 24h136v96c0 21.5 26 32 41 17l168-168c9.3-9.4 9.3-24.6 0-34z"></path>
+                </svg>
+                Sign in
+              </button>
             </div>
             <div class="clearfix">
               <details class="details-popup display-inline-block float-right">


### PR DESCRIPTION
TIL that `<button type="submit">` can do the same as `<input type="submit">`

Before

<img width="314" alt="Screen Shot 2020-09-08 at 2 55 55 PM" src="https://user-images.githubusercontent.com/458784/92634269-e504ea00-f288-11ea-8e29-5ed0dd6fe7ad.png">


Current

 
<img width="328" alt="Screen Shot 2020-09-08 at 2 56 03 PM" src="https://user-images.githubusercontent.com/458784/92634281-e9c99e00-f288-11ea-86e2-ce329d39bc23.png">


After

<img width="247" alt="Screen Shot 2020-09-09 at 10 38 20 AM" src="https://user-images.githubusercontent.com/458784/92634294-ed5d2500-f288-11ea-82d6-bf5af388b4f0.png">
