### PR TITLE
Cache IDP OpenID Connect configuration

### DIFF
--- a/config.rb
+++ b/config.rb
@@ -40,6 +40,10 @@ module LoginGov
         @config.fetch('redact_ssn')
       end
 
+      def cache_oidc_config?
+        @config.fetch('cache_oidc_config')
+      end
+
       # @return [OpenSSL::PKey::RSA]
       def sp_private_key
         return @sp_private_key if @sp_private_key
@@ -60,6 +64,7 @@ module LoginGov
           'redirect_uri' => ENV['redirect_uri'] || 'http://localhost:9292/',
           'sp_private_key_path' => ENV['sp_private_key_path'] || './config/demo_sp.key',
           'redact_ssn'   => true,
+          'cache_oidc_config' => true,
         }
 
         # EC2 deployment defaults

--- a/config/application.yml.example
+++ b/config/application.yml.example
@@ -4,3 +4,4 @@ acr_values: 'http://idmanagement.gov/ns/assurance/loa/1'
 redirect_uri: 'http://localhost:9292/'
 client_id: 'urn:gov:gsa:openidconnect:sp:sinatra'
 sp_private_key_path: 'config/demo_sp.key'
+cache_oidc_config: True

--- a/openid_configuration.rb
+++ b/openid_configuration.rb
@@ -1,0 +1,32 @@
+require 'httparty'
+require_relative './config'
+
+module LoginGov
+  module OidcSinatra
+    class OpenidConfiguration
+      def self.cached
+        @config ||= live
+      end
+
+      def self.live
+        config = Config.new
+        begin
+          response = HTTParty.get(URI.join(config.idp_url, '/.well-known/openid-configuration'))
+
+          if response.code == 200
+            JSON.parse(response.body).with_indifferent_access
+          else
+            msg = 'Error: Unable to retrieve OIDC configuration from IdP.'
+            msg += " #{config.idp_url} responded with #{response.code}."
+
+            if response.code == 401
+              msg += ' Perhaps we need to reimplement HTTP Basic Auth.'
+            end
+
+            raise AppError.new(msg)
+          end
+        end
+      end
+    end
+  end
+end

--- a/spec/app_spec.rb
+++ b/spec/app_spec.rb
@@ -12,6 +12,7 @@ RSpec.describe LoginGov::OidcSinatra::OpenidConnectRelyingParty do
   let(:client_id) { 'urn:gov:gsa:openidconnect:sp:sinatra' }
 
   before do
+    allow_any_instance_of(LoginGov::OidcSinatra::Config).to receive(:cache_oidc_config?).and_return(false)
     stub_request(:get, "#{host}/.well-known/openid-configuration").
       to_return(body: {
         authorization_endpoint: authorization_endpoint,

--- a/spec/openid_configuration_spec.rb
+++ b/spec/openid_configuration_spec.rb
@@ -1,0 +1,42 @@
+require 'spec_helper'
+
+RSpec.describe LoginGov::OidcSinatra::OpenidConfiguration do
+  let(:host) { 'http://localhost:3000' }
+  let(:authorization_endpoint) { "#{host}/openid/authorize" }
+  let(:token_endpoint) { "#{host}/api/openid/token" }
+  let(:jwks_uri) { "#{host}/api/openid/certs" }
+  let(:end_session_endpoint) { "#{host}/openid/logout" }
+  let(:client_id) { 'urn:gov:gsa:openidconnect:sp:sinatra' }
+
+  before do
+    stub_request(:get, "#{host}/.well-known/openid-configuration").
+      to_return(body: {
+        authorization_endpoint: authorization_endpoint,
+        token_endpoint: token_endpoint,
+        jwks_uri: jwks_uri,
+        end_session_endpoint: end_session_endpoint,
+      }.to_json)
+  end
+
+  describe '#live' do
+    it 'raises error if request fails' do
+      stub_request(:get, "#{host}/.well-known/openid-configuration").
+        to_return(body: '', status: 401)
+
+      expect { LoginGov::OidcSinatra::OpenidConfiguration.live }.
+        to raise_error(LoginGov::OidcSinatra::AppError)
+    end
+  end
+
+  describe '#cached' do
+    after(:each) do
+      WebMock.enable!
+    end
+    it 'does not make more than one HTTP request' do
+      oidc_config = LoginGov::OidcSinatra::OpenidConfiguration.cached
+      WebMock.disable!
+      cached_oidc_config = LoginGov::OidcSinatra::OpenidConfiguration.cached
+      expect(oidc_config).to eq cached_oidc_config
+    end
+  end
+end

--- a/spec/openid_configuration_spec.rb
+++ b/spec/openid_configuration_spec.rb
@@ -8,6 +8,8 @@ RSpec.describe LoginGov::OidcSinatra::OpenidConfiguration do
   let(:end_session_endpoint) { "#{host}/openid/logout" }
   let(:client_id) { 'urn:gov:gsa:openidconnect:sp:sinatra' }
 
+  let(:configuration_uri) { "#{host}/.well-known/openid-configuration" }
+
   before do
     stub_request(:get, "#{host}/.well-known/openid-configuration").
       to_return(body: {
@@ -29,14 +31,11 @@ RSpec.describe LoginGov::OidcSinatra::OpenidConfiguration do
   end
 
   describe '#cached' do
-    after(:each) do
-      WebMock.enable!
-    end
     it 'does not make more than one HTTP request' do
       oidc_config = LoginGov::OidcSinatra::OpenidConfiguration.cached
-      WebMock.disable!
       cached_oidc_config = LoginGov::OidcSinatra::OpenidConfiguration.cached
       expect(oidc_config).to eq cached_oidc_config
+      expect(a_request(:get, configuration_uri)).to have_been_made.once
     end
   end
 end


### PR DESCRIPTION
Adds caching for the OpenID config the response for the first request. This behavior is configurable, but defaults to true.

This is to help make load-testing match more closely to production by not making multiple requests on each authentication.