### PR TITLE
allow user to explicitly request AAL2

### DIFF
--- a/app.rb
+++ b/app.rb
@@ -163,6 +163,8 @@ module LoginGov::OidcSinatra
       end
 
       values << case aal
+      when '2'
+        'http://idmanagement.gov/ns/assurance/aal/2'
       when '3'
         'http://idmanagement.gov/ns/assurance/aal/3'
       when '3-hspd12'

--- a/views/index.erb
+++ b/views/index.erb
@@ -103,6 +103,7 @@
                 <select name="aal" id="aal" class="usa-select">
                   <% [
                     ['', 'Default'],
+                    ['2', 'AAL 2'],
                     ['3', 'AAL 3'],
                     ['3-hspd12', 'HSPD12 required'],
                   ].each do |value, label| %>


### PR DESCRIPTION
I want to be able to send an AAL2 request to properly test out the default AAL setting.