### PR TITLE
Support configurable hostname

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,6 +4,7 @@
 # than one or two lines should live in script files of their own in the
 # bin/ directory.
 
+HOST ?= localhost
 PORT ?= 9292
 
 all: check
@@ -21,7 +22,7 @@ lint:
 	bundle exec reek
 
 run:
-	bundle exec rackup -p $(PORT)
+	bundle exec rackup -p $(PORT) --host ${HOST}
 
 test: $(CONFIG)
 	bundle exec rspec

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ An example of a Relying Party for OpenID Connect written as a simple Sinatra app
 
 ## Running locally
 
-These instructions assume [`identity-idp`](https://github.com/18F/identity-idp) is also running locally at `http://localhost:3000`. This sample sp is configured to run on `http://localhost:9292`.
+These instructions assume [`identity-idp`](https://github.com/18F/identity-idp) is also running locally at http://localhost:3000 .
 
 1. Set up the environment with:
 
@@ -23,6 +23,8 @@ These instructions assume [`identity-idp`](https://github.com/18F/identity-idp) 
   ```
   $ make test
   ```
+
+This sample service provider is configured to run on http://localhost:9292 by default. Optionally, you can assign a custom hostname or port by passing `HOST=` or `PORT=` environment variables when starting the application server.
 
 ## Contributing
 


### PR DESCRIPTION
**Why**: As a developer, I want to be able to override the default localhost hostname, so that I can test an SP login flow entirely from a network device or virtual machine.

Complementary changes to https://github.com/18F/identity-idp/pull/4708