### PR TITLE
Deploy to Cloud.gov from main (dev, int)

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,7 +2,7 @@
 #
 # Check https://circleci.com/docs/2.0/language-ruby/ for more details
 #
-version: 2
+version: 2.1
 jobs:
   build:
     docker:
@@ -46,6 +46,9 @@ jobs:
     docker:
       - image: circleci/ruby:2.6.5
     working_directory: ~/identity-oidc-sinatra
+    parameters:
+      space:
+        type: string
     steps:
       - checkout
 
@@ -69,12 +72,12 @@ jobs:
       - run:
           name: login to cloud.gov
           command: |
-            cf login -a https://api.fr.cloud.gov -u "4fbf18ec-1497-433f-814f-8c175041a6f1" -p $CF_PASS -o "gsa-login-prototyping" -s "int"
+            cf login -a https://api.fr.cloud.gov -u "4fbf18ec-1497-433f-814f-8c175041a6f1" -p $CF_PASS -o "gsa-login-prototyping" -s "<< parameters.space >>"
 
       - run:
           name: deploy to cloud.gov
           command: |
-            cf push int-identity-oidc-sinatra
+            cf push << parameters.space >>-identity-oidc-sinatra
 
       - save_cache:
           key: identity-oidc-sinatra-{{ checksum "Gemfile.lock" }}
@@ -92,3 +95,8 @@ workflows:
           filters:
             branches:
               only: main
+          matrix:
+            parameters:
+              space:
+                - int
+                - dev

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -13,7 +13,7 @@ jobs:
     steps:
       - checkout
 
-      - restore-cache:
+      - restore_cache:
           key: identity-oidc-sinatra-{{ checksum "Gemfile.lock" }}
 
       - run:
@@ -25,7 +25,7 @@ jobs:
             bundle exec rake login:deploy_json
 
       # Store bundle cache
-      - save-cache:
+      - save_cache:
           key: identity-oidc-sinatra-{{ checksum "Gemfile.lock" }}
           paths:
             - vendor/bundle

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -91,4 +91,4 @@ workflows:
             - build
           filters:
             branches:
-              only: master
+              only: main


### PR DESCRIPTION
Previously: #67

This pull request seeks to...

- Deploy from `main`, previously implemented in #67, but non-functional after main branch rename from `master`
- Deploy to `dev` in addition to `int`, using CircleCI matrix feature ([reference](https://circleci.com/docs/2.0/configuration-reference/#matrix-requires-version-21), [guide](https://circleci.com/blog/circleci-matrix-jobs/))