### PR TITLE
LG-5120: update circleci ruby image

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -7,7 +7,7 @@ version: 2.1
 executors:
   ruby_browsers:
     docker:
-      - image: circleci/ruby:2.7.3-node-browsers
+      - image: cimg/ruby:2.7.3-browsers
         environment:
           BUNDLER_VERSION: 2.2.20
 


### PR DESCRIPTION
An email from CircleCI:

> As of Dec 31, 2021, legacy images will no longer be supported on CircleCI