### PR TITLE
Deploy to DM from CircleCI (LG-4881)

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -119,3 +119,4 @@ workflows:
                 - staging
                 - int
                 - dev
+                - dm


### PR DESCRIPTION
Based on LG-4881 (Adding DM to Dashboard)

Based on previous commits, it looks like this should be the only change that is necessary, and that CircleCI should be able to successfully deploy this environment once this is merged into main?