### PR TITLE
LG-5534: simulate the step up flow

### DIFF
--- a/spec/app_spec.rb
+++ b/spec/app_spec.rb
@@ -59,8 +59,8 @@ RSpec.describe LoginGov::OidcSinatra::OpenidConnectRelyingParty do
       expect(last_response).to be_ok
 
       doc = Nokogiri::HTML(last_response.body)
-      ial2_option = doc.at("select[name=aal] option[value=3]")
-      expect(ial2_option[:selected]).to be
+      aal3_option = doc.at("select[name=aal] option[value=3]")
+      expect(aal3_option[:selected]).to be
     end
 
     it 'renders an error if basic auth credentials are wrong' do
@@ -109,7 +109,7 @@ RSpec.describe LoginGov::OidcSinatra::OpenidConnectRelyingParty do
       )
     end
 
-    it 'redirects to an ial1 sign in link if loa param is 1' do
+    it 'redirects to an ial1 sign in link if ial param is 1' do
       get '/auth/request?ial=1'
 
       expect(last_response).to be_redirect
@@ -136,6 +136,16 @@ RSpec.describe LoginGov::OidcSinatra::OpenidConnectRelyingParty do
       expect(last_response).to be_redirect
       expect(CGI.unescape(last_response.location)).to include(
         '/ial/2?strict=true'
+      )
+    end
+
+    it 'redirects to an ial1 sign in link if ial param is step-up' do
+      get '/auth/request?ial=step-up'
+
+      expect(last_response).to be_redirect
+      expect(last_response.location).to include('scope=openid+email')
+      expect(last_response.location).to_not include(
+        'scope=openid+email+profile+social_security_number+phone+address'
       )
     end
 

--- a/views/index.erb
+++ b/views/index.erb
@@ -124,6 +124,7 @@
                     ['2', 'IAL  2'],
                     ['2-strict', 'IAL 2 (strict)'],
                     ['0', 'IAL Max'],
+                    ['step-up', 'Step-up Flow']
                   ].each do |value, label| %>
                     <option value="<%= value %>"
                             <%= 'selected="true"' if ial == value %>


### PR DESCRIPTION
A new IAL option of `Step-up` will initially send an IAL1 request. Upon receipt of the response, the app will immediately turn around and send an IAL2 request. This simulates the step-up flow in use by a few of our partners.

To accomplish this, we set session variables indicating we are in the step up flow, and caching the AAL level for the flow.