### PR TITLE
Add puma dependency

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -12,6 +12,7 @@ gem 'faraday'
 gem 'json-jwt', '~> 1.11.0'
 gem 'jwt', '~> 2.1'
 gem 'nokogiri', '>= 1.11.0'
+gem 'puma', '~> 5.6'
 gem 'rake'
 gem 'sinatra', '~> 2.2'
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -51,6 +51,7 @@ GEM
     minitest (5.15.0)
     mustermann (1.1.1)
       ruby2_keywords (~> 0.0.1)
+    nio4r (2.5.8)
     nokogiri (1.13.6)
       mini_portile2 (~> 2.8.0)
       racc (~> 1.4)
@@ -64,6 +65,8 @@ GEM
       byebug (~> 11.0)
       pry (~> 0.13.0)
     public_suffix (4.0.7)
+    puma (5.6.4)
+      nio4r (~> 2.0)
     racc (1.6.0)
     rack (2.2.3)
     rack-protection (2.2.0)
@@ -134,6 +137,7 @@ DEPENDENCIES
   jwt (~> 2.1)
   nokogiri (>= 1.11.0)
   pry-byebug
+  puma (~> 5.6)
   rack-test (>= 1.1.0)
   rake
   reek


### PR DESCRIPTION
**Why**: So that Rack has a web server to work with in Ruby 3.

Context: https://github.com/18F/identity-oidc-sinatra/pull/110#issuecomment-1133138512

_Before:_

```
$ make run
bundle exec rackup -p 9292 --host localhost
bundler: failed to load command: rackup (/.rbenv/versions/3.0/bin/rackup)
/.rbenv/versions/3.0.3/lib/ruby/gems/3.0.0/gems/rack-2.2.3/lib/rack/handler.rb:45:in `pick': Couldn't find handler for: puma, thin, falcon, webrick. (LoadError)
```

_After:_

```
$ make run
bundle exec rackup -p 9292 --host localhost
Puma starting in single mode...
* Puma version: 5.6.4 (ruby 3.0.3-p157) ("Birdie's Version")
*  Min threads: 0
*  Max threads: 5
*  Environment: development
*          PID: 73046
* Listening on http://127.0.0.1:9292
* Listening on http://[::1]:9292
```