### PR TITLE
Add option to simulate a CSP error when signing in

### DIFF
--- a/views/index.erb
+++ b/views/index.erb
@@ -103,8 +103,8 @@
                 <select name="aal" id="aal" class="usa-select">
                   <% [
                     ['', 'Default'],
-                    ['2', 'AAL 2'],
-                    ['3', 'AAL 3'],
+                    ['2', 'AAL2'],
+                    ['3', 'Phishing-resistant AAL2'],
                     ['3-hspd12', 'HSPD12 required'],
                   ].each do |value, label| %>
                     <option value="<%= value %>"
@@ -116,14 +116,14 @@
                 </select>
 
                 <label class="usa-label" for="ial">
-                  Identity Assurance Level (IAL)
+                  Level of Service
                 </label>
                 <select name="ial" id="ial" class="usa-select">
                   <% [
-                    ['1', 'IAL 1 (Default)'],
-                    ['2', 'IAL  2'],
-                    ['2-strict', 'IAL 2 (strict)'],
-                    ['0', 'IAL Max'],
+                    ['1', 'Authentication only (default)'],
+                    ['2', 'Identity-verified'],
+                    ['2-strict', 'Identity-verified (strict)'],
+                    ['0', 'IALMax'],
                     ['step-up', 'Step-up Flow']
                   ].each do |value, label| %>
                     <option value="<%= value %>"
@@ -133,6 +133,17 @@
                     </option>
                   <% end %>
                 </select>
+                <div class="usa-checkbox">
+                  <input class="usa-checkbox__input"
+                         id="check-simulate_csp"
+                         type="checkbox"
+                         name="simulate_csp"
+                         value="true"
+                  />
+                  <label class="usa-checkbox__label" for="check-simulate_csp">
+                    Simulate CSP Error
+                  </label>
+                </div>
               </details>
             </div>
           </div>


### PR DESCRIPTION
**Why:** we didn't have a way to trigger a CSP error due to a missing
redirect URI, which made it difficult to generate documentation on how
to troubleshoot and resolve said issues. This commit adds a checkbox to
the authentication options that, if selected, will redirect the user to
https://www.example.com after authentication, which should not be
configured as a redirect URI in the Dashboard. This will trigger a CSP
error on the redirect in Chrome and Chromium-based browsers.

Also includes some language updates around the authentication options
to remove references to IAL2.