### PR TITLE
LG-7472 add inherited proofing user option

### DIFF
--- a/app.rb
+++ b/app.rb
@@ -154,14 +154,6 @@ module LoginGov::OidcSinatra
       "#{endpoint}?#{request_params}"
     end
 
-    def user_options
-      ip_auth_option = params['ip_auth_option']
-
-      {}.tap do |options|
-        options[:inherited_proofing_auth] = random_value if ip_auth_option
-      end
-    end
-
     def simulate_csp_issue_if_selected(session:, simulate_csp:)
       if simulate_csp
         session[:simulate_csp] = 'true'

--- a/app.rb
+++ b/app.rb
@@ -21,8 +21,6 @@ module LoginGov::OidcSinatra
   class AppError < StandardError; end
 
   class OpenidConnectRelyingParty < Sinatra::Base
-    VA_TEST_AUTH_CODE = 'mocked-auth-code-for-testing'
-
     set :erb, escape_html: true
     set :logger, proc { Logger.new(ENV['RACK_ENV'] == 'test' ? nil : $stdout) }
 
@@ -148,7 +146,7 @@ module LoginGov::OidcSinatra
         state: random_value,
         nonce: random_value,
         prompt: 'select_account',
-        inherited_proofing_auth: params['ip_auth_option'] ? VA_TEST_AUTH_CODE : nil,
+        inherited_proofing_auth: params['ip_auth_option'].presence,
       }.compact.to_query
 
       "#{endpoint}?#{request_params}"

--- a/app.rb
+++ b/app.rb
@@ -69,7 +69,7 @@ module LoginGov::OidcSinatra
 
       idp_url = authorization_url(ial: ial, aal: params[:aal])
 
-      logger.info("Redirecting to #{idp_url}")
+      settings.logger.info("Redirecting to #{idp_url}") if ENV['RACK_ENV'] != 'test'
 
       redirect to(idp_url)
     end
@@ -146,9 +146,19 @@ module LoginGov::OidcSinatra
         state: random_value,
         nonce: random_value,
         prompt: 'select_account',
-      }.to_query
+      }
 
-      "#{endpoint}?#{request_params}"
+      request_params.merge!(user_options)
+
+      "#{endpoint}?#{request_params.to_query}"
+    end
+
+    def user_options
+      ip_auth_option = params['ip_auth_option']
+
+      {}.tap do |options|
+        options[:inherited_proofing_auth] = random_value if ip_auth_option
+      end
     end
 
     def simulate_csp_issue_if_selected(session:, simulate_csp:)

--- a/spec/app_spec.rb
+++ b/spec/app_spec.rb
@@ -41,6 +41,7 @@ RSpec.describe LoginGov::OidcSinatra::OpenidConnectRelyingParty do
       expect(auth_uri_params[:prompt]).to eq('select_account')
       expect(auth_uri_params[:nonce].length).to be >= 32
       expect(auth_uri_params[:state].length).to be >= 32
+      expect(auth_uri_params[:inherited_proofing_auth]).not_to be
     end
 
     it 'pre-fills IAL2 if the URL has ?ial=2 (used in smoke tests)' do
@@ -84,6 +85,19 @@ RSpec.describe LoginGov::OidcSinatra::OpenidConnectRelyingParty do
       expect(last_response.body).to include(error_string)
       expect(stub).to have_been_requested.once
       expect(last_response.status).to eq 500
+    end
+
+    context 'user options' do
+      it 'adds the inherited proofing auth URL param when selected by user' do
+        get '/', { ip_auth_option: true }
+
+        doc = Nokogiri::HTML(last_response.body)
+        login_link = doc.at("a[href*='#{authorization_endpoint}']")
+        auth_uri = URI(login_link[:href])
+        auth_uri_params = Rack::Utils.parse_nested_query(auth_uri.query).with_indifferent_access
+
+        expect(auth_uri_params[:inherited_proofing_auth]).not_to be_empty
+      end
     end
   end
 

--- a/spec/app_spec.rb
+++ b/spec/app_spec.rb
@@ -89,7 +89,11 @@ RSpec.describe LoginGov::OidcSinatra::OpenidConnectRelyingParty do
 
     context 'user options' do
       it 'adds the (VA test) inherited proofing auth URL param when selected by user' do
-        va_test_auth_code = 'mocked-auth-code-for-testing'
+        get '/'
+
+        doc = Nokogiri::HTML(last_response.body)
+
+        va_test_auth_code = doc.at('[name=ip_auth_option]').attr('value')
 
         get '/', { ip_auth_option: va_test_auth_code }
 

--- a/spec/app_spec.rb
+++ b/spec/app_spec.rb
@@ -88,15 +88,17 @@ RSpec.describe LoginGov::OidcSinatra::OpenidConnectRelyingParty do
     end
 
     context 'user options' do
-      it 'adds the inherited proofing auth URL param when selected by user' do
-        get '/', { ip_auth_option: true }
+      it 'adds the (VA test) inherited proofing auth URL param when selected by user' do
+        va_test_auth_code = 'mocked-auth-code-for-testing'
+
+        get '/', { ip_auth_option: va_test_auth_code }
 
         doc = Nokogiri::HTML(last_response.body)
         login_link = doc.at("a[href*='#{authorization_endpoint}']")
         auth_uri = URI(login_link[:href])
         auth_uri_params = Rack::Utils.parse_nested_query(auth_uri.query).with_indifferent_access
 
-        expect(auth_uri_params[:inherited_proofing_auth]).not_to be_empty
+        expect(auth_uri_params[:inherited_proofing_auth]).to eq(va_test_auth_code)
       end
     end
   end

--- a/views/index.erb
+++ b/views/index.erb
@@ -149,7 +149,7 @@
                          id="ip-auth-option"
                          type="checkbox"
                          name="ip_auth_option"
-                         value="true"
+                         value="mocked-auth-code-for-testing"
                   />
                   <label class="usa-checkbox__label" for="ip-auth-option">
                     Enable inherited proofing

--- a/views/index.erb
+++ b/views/index.erb
@@ -144,6 +144,17 @@
                     Simulate CSP Error
                   </label>
                 </div>
+                <div class="usa-checkbox">
+                  <input class="usa-checkbox__input"
+                         id="ip-auth-option"
+                         type="checkbox"
+                         name="ip_auth_option"
+                         value="true"
+                  />
+                  <label class="usa-checkbox__label" for="ip-auth-option">
+                    Enable inherited proofing
+                  </label>
+                </div>
               </details>
             </div>
           </div>


### PR DESCRIPTION
  - renders a checkbox that enables addition of the inherited_proofing_auth URL param