### PR TITLE
LG-7712 Remove IAl2 strict option from the sample app

### DIFF
--- a/app.rb
+++ b/app.rb
@@ -193,7 +193,6 @@ module LoginGov::OidcSinatra
         '' => 'http://idmanagement.gov/ns/assurance/ial/1',
         '1' => 'http://idmanagement.gov/ns/assurance/ial/1',
         '2' => 'http://idmanagement.gov/ns/assurance/ial/2',
-        '2-strict' => 'http://idmanagement.gov/ns/assurance/ial/2?strict=true',
       }[ial]
 
       values << {

--- a/spec/app_spec.rb
+++ b/spec/app_spec.rb
@@ -150,15 +150,6 @@ RSpec.describe LoginGov::OidcSinatra::OpenidConnectRelyingParty do
       )
     end
 
-    it 'redirects to an ial2 strict sign in link if ial param is 2-strict' do
-      get '/auth/request?ial=2-strict'
-
-      expect(last_response).to be_redirect
-      expect(CGI.unescape(last_response.location)).to include(
-        '/ial/2?strict=true'
-      )
-    end
-
     it 'redirects to an ial1 sign in link if ial param is step-up' do
       get '/auth/request?ial=step-up'
 

--- a/views/index.erb
+++ b/views/index.erb
@@ -122,7 +122,6 @@
                   <% [
                     ['1', 'Authentication only (default)'],
                     ['2', 'Identity-verified'],
-                    ['2-strict', 'Identity-verified (strict)'],
                     ['0', 'IALMax'],
                     ['step-up', 'Step-up Flow']
                   ].each do |value, label| %>


### PR DESCRIPTION
This commit removes the IAL2 strict option since we are retiring that while we work on buiding out re-proofing for IRS