### PR TITLE
LG-7737 add simulate failure user option for inherited proofing

### DIFF
--- a/app.rb
+++ b/app.rb
@@ -205,7 +205,7 @@ module LoginGov::OidcSinatra
         '3-hspd12' => 'http://idmanagement.gov/ns/assurance/aal/3?hspd12=true',
       }[aal]
 
-      values.join(' ')
+      values.compact.join(' ')
     end
 
     def openid_configuration

--- a/app.rb
+++ b/app.rb
@@ -45,6 +45,7 @@ module LoginGov::OidcSinatra
       erb :index, locals: {
         ial: params[:ial],
         aal: params[:aal],
+        ip_auth_option: params[:ip_auth_option],
         ial_url: authorization_url(ial: ial, aal: params[:aal]),
         login_msg: login_msg,
         logout_msg: logout_msg,
@@ -55,9 +56,8 @@ module LoginGov::OidcSinatra
       }
     rescue AppError => e
       [500, erb(:errors, locals: { error: e.message })]
-    rescue Errno::ECONNREFUSED => e
+    rescue Errno::ECONNREFUSED, Faraday::ConnectionFailed => e
       [500, erb(:errors, locals: { error: e.inspect })]
-
     end
 
     get '/auth/request' do
@@ -65,7 +65,11 @@ module LoginGov::OidcSinatra
 
       ial = prepare_step_up_flow(session: session, ial: params[:ial], aal: params[:aal])
 
-      idp_url = authorization_url(ial: ial, aal: params[:aal], enable_attempts_api: params[:enable_attempts_api])
+      idp_url = authorization_url(
+        ial: ial,
+        aal: params[:aal],
+        enable_attempts_api: params[:enable_attempts_api]
+      )
 
       settings.logger.info("Redirecting to #{idp_url}")
 

--- a/public/assets/css/sign-in.css
+++ b/public/assets/css/sign-in.css
@@ -28,6 +28,7 @@
 }
 
 .details-popup[open] {
+  width: 120%;
   background: white;
   border: 2px solid black;
   border-radius: 3px;

--- a/spec/app_spec.rb
+++ b/spec/app_spec.rb
@@ -88,21 +88,17 @@ RSpec.describe LoginGov::OidcSinatra::OpenidConnectRelyingParty do
     end
 
     context 'user options' do
-      it 'adds the (VA test) inherited proofing auth URL param when selected by user' do
-        get '/'
+      it 'adds inherited proofing auth_code URL param to authorization endpoint when selected by user' do
+        auth_code = 'auth_code_selected_by_user'
 
-        doc = Nokogiri::HTML(last_response.body)
-
-        va_test_auth_code = doc.at('[name=ip_auth_option]').attr('value')
-
-        get '/', { ip_auth_option: va_test_auth_code }
+        get '/', { ip_auth_option: auth_code }
 
         doc = Nokogiri::HTML(last_response.body)
         login_link = doc.at("a[href*='#{authorization_endpoint}']")
         auth_uri = URI(login_link[:href])
         auth_uri_params = Rack::Utils.parse_nested_query(auth_uri.query).with_indifferent_access
 
-        expect(auth_uri_params[:inherited_proofing_auth]).to eq(va_test_auth_code)
+        expect(auth_uri_params[:inherited_proofing_auth]).to eq(auth_code)
       end
     end
   end

--- a/views/index.erb
+++ b/views/index.erb
@@ -132,6 +132,25 @@
                     </option>
                   <% end %>
                 </select>
+
+                <label class="usa-label" for="ip-auth-option">
+                  Inherited Proofing
+                </label>
+                <select name="ip_auth_option" id="ip-auth-option" class="usa-select">
+                  <% [
+                    ['', 'Disabled'],
+                    ['mocked-auth-code-for-testing', 'Enabled'],
+                    ['mocked-auth-code-for-failure', 'Simulate failure'],
+                  ].each do |value, label| %>
+                    <option value="<%= value %>"
+                            <%= 'selected="true"' if ip_auth_option == value %>
+                            >
+                      <%= label %>
+                    </option>
+                  <% end %>
+                </select>
+
+                <hr/>
                 <div class="usa-checkbox">
                   <input class="usa-checkbox__input"
                          id="check-simulate_csp"
@@ -152,17 +171,6 @@
                     />
                   <label class="usa-checkbox__label" for="check_enable_attempts_api">
                     Enable attempts api
-                  </label>
-                </div>
-                <div class="usa-checkbox">
-                  <input class="usa-checkbox__input"
-                         id="ip-auth-option"
-                         type="checkbox"
-                         name="ip_auth_option"
-                         value="mocked-auth-code-for-testing"
-                  />
-                  <label class="usa-checkbox__label" for="ip-auth-option">
-                    Enable inherited proofing
                   </label>
                 </div>
               </details>
@@ -193,29 +201,33 @@
         <% end %>
       </div>
     </div>
-        <% if userinfo %>
-          <div class="userinfo">
-            <div class="p2 clearfix bg-white fg-black">
-              <span>Received user info:</span>
-                <% case userinfo.fetch('acr')
-                     when 'http://idmanagement.gov/ns/assurance/loa/3' %>
-                  <span>Login type: <strong>LOA3</strong></span>
-                  <span class="ml1 mr1">|</span>
-                  <span>SSN: <strong><%= maybe_redact_ssn(userinfo[:social_security_number]) %></strong></span>
-                <% when 'http://idmanagement.gov/ns/assurance/loa/1' %>
-                  <span>Login type: <strong>LOA1</strong></span>
-                <% else %>
-                  <span>Login type: <strong>Unexpected ACR: <%= userinfo.fetch('acr') %></strong></span>
-                <% end %>
-              <ul>
+    <% if userinfo %>
+      <div class="userinfo">
+        <div class="p2 clearfix bg-white fg-black">
+          Received user info:<br/>
+          <% case userinfo.fetch('acr')
+             when 'http://idmanagement.gov/ns/assurance/loa/3' %>
+            Login type: <strong>LOA3</strong><br/>
+            < class="ml1 mr1">|<br/>
+            SSN: <strong><%= maybe_redact_ssn(userinfo[:social_security_number]) %></strong><br/>
+          <% when 'http://idmanagement.gov/ns/assurance/loa/1' %>
+            Login type: <strong>LOA1</strong><br/>
+          <% else %>
+            Login type: <strong>Unexpected ACR: <%= userinfo.fetch('acr') %></strong><br/>
+          <% end %>
+          <div>
+            <ul>
               <% userinfo.each_pair do |key, val| %>
                 <% val = maybe_redact_ssn(val) if key.to_s == 'social_security_number' %>
-                <li><pre><%= key.inspect %>: <%= val.inspect %></pre></li>
+                <li>
+                  <pre><%= key.inspect %>: <%= val.inspect %></pre>
+                </li>
               <% end %>
-              </ul>
-            </div>
+            </ul>
           </div>
-        <% end %>
+        </div>
+      </div>
+    <% end %>
   </section>
   <section class="grid-container usa-section">
     <div class="grid-row grid-gap">

--- a/views/index.erb
+++ b/views/index.erb
@@ -102,14 +102,12 @@
                 </label>
                 <select name="aal" id="aal" class="usa-select">
                   <% [
-                    ['', 'Default'],
-                    ['2', 'AAL2'],
-                    ['3', 'Phishing-resistant AAL2'],
-                    ['3-hspd12', 'HSPD12 required'],
-                  ].each do |value, label| %>
-                    <option value="<%= value %>"
-                            <%= 'selected="true"' if aal == value %>
-                            >
+                       ['', 'Default'],
+                       ['2', 'AAL2'],
+                       ['3', 'Phishing-resistant AAL2'],
+                       ['3-hspd12', 'HSPD12 required'],
+                     ].each do |value, label| %>
+                    <option value="<%= value %>" <%= 'selected' if aal == value %> >
                       <%= label %>
                     </option>
                   <% end %>
@@ -120,14 +118,12 @@
                 </label>
                 <select name="ial" id="ial" class="usa-select">
                   <% [
-                    ['1', 'Authentication only (default)'],
-                    ['2', 'Identity-verified'],
-                    ['0', 'IALMax'],
-                    ['step-up', 'Step-up Flow']
-                  ].each do |value, label| %>
-                    <option value="<%= value %>"
-                            <%= 'selected="true"' if ial == value %>
-                            >
+                       ['1', 'Authentication only (default)'],
+                       ['2', 'Identity-verified'],
+                       ['0', 'IALMax'],
+                       ['step-up', 'Step-up Flow']
+                     ].each do |value, label| %>
+                    <option value="<%= value %>" <%= 'selected' if ial == value %> >
                       <%= label %>
                     </option>
                   <% end %>
@@ -138,13 +134,11 @@
                 </label>
                 <select name="ip_auth_option" id="ip-auth-option" class="usa-select">
                   <% [
-                    ['', 'Disabled'],
-                    ['mocked-auth-code-for-testing', 'Enabled'],
-                    ['mocked-auth-code-for-failure', 'Simulate failure'],
-                  ].each do |value, label| %>
-                    <option value="<%= value %>"
-                            <%= 'selected="true"' if ip_auth_option == value %>
-                            >
+                       ['', 'Disabled'],
+                       ['mocked-auth-code-for-testing', 'Enabled'],
+                       ['mocked-auth-code-for-failure', 'Simulate failure'],
+                     ].each do |value, label| %>
+                    <option value="<%= value %>" <%= 'selected' if ip_auth_option == value %> >
                       <%= label %>
                     </option>
                   <% end %>
@@ -207,8 +201,7 @@
           Received user info:<br/>
           <% case userinfo.fetch('acr')
              when 'http://idmanagement.gov/ns/assurance/loa/3' %>
-            Login type: <strong>LOA3</strong><br/>
-            < class="ml1 mr1">|<br/>
+            Login type: <strong>LOA3 |</strong>
             SSN: <strong><%= maybe_redact_ssn(userinfo[:social_security_number]) %></strong><br/>
           <% when 'http://idmanagement.gov/ns/assurance/loa/1' %>
             Login type: <strong>LOA1</strong><br/>


### PR DESCRIPTION

  - increase user option menu width to compact the dropdown menu
  - rescue Faraday connection failure to better render error (when IDP server not available for openid-configuration)
  - fix presentation of userinfo in /auth/result to properly display error and user info