### PR TITLE
LG-7716: if `enable_attempts_api` is checked, change SP to mock IRS

### DIFF
--- a/app.rb
+++ b/app.rb
@@ -138,8 +138,9 @@ module LoginGov::OidcSinatra
     def authorization_url(ial:, aal: nil, enable_attempts_api: nil)
       endpoint = openid_configuration[:authorization_endpoint]
       irs_attempts_api_session_id = enable_attempts_api ? random_value : nil
+      issuer = enable_attempts_api ? config.mock_irs_client_id : config.client_id
       request_params = {
-        client_id: config.client_id,
+        client_id: issuer,
         response_type: 'code',
         acr_values: acr_values(ial: ial, aal: aal),
         scope: scopes_for(ial),

--- a/config.rb
+++ b/config.rb
@@ -37,6 +37,10 @@ module LoginGov
         @config.fetch('client_id')
       end
 
+      def mock_irs_client_id
+        @config.fetch('mock_irs_client_id')
+      end
+
       def redact_ssn?
         @config.fetch('redact_ssn')
       end
@@ -62,6 +66,8 @@ module LoginGov
         data = {
           'acr_values' => ENV['acr_values'] || 'http://idmanagement.gov/ns/assurance/ial/1',
           'client_id' => ENV['client_id'] || 'urn:gov:gsa:openidconnect:sp:sinatra',
+          'mock_irs_client_id' => ENV['mock_irs_client_id'] ||
+                                  'urn:gov:gsa:openidconnect:sp:mock_irs',
           'redirect_uri' => ENV['redirect_uri'] || 'http://localhost:9292/',
           'sp_private_key_path' => ENV['sp_private_key_path'] || './config/demo_sp.key',
           'redact_ssn' => true,

--- a/config/application.yml.example
+++ b/config/application.yml.example
@@ -3,5 +3,6 @@ idp_url: 'http://localhost:3000'
 acr_values: 'http://idmanagement.gov/ns/assurance/loa/1'
 redirect_uri: 'http://localhost:9292/'
 client_id: 'urn:gov:gsa:openidconnect:sp:sinatra'
+mock_irs_client_id: 'urn:gov:gsa:openidconnect:sp:mock_irs'
 sp_private_key_path: 'config/demo_sp.key'
 cache_oidc_config: true


### PR DESCRIPTION
To simulate IRS reproofing, we need to simulate that we are coming from an IRS SP, i.e., and SP with `irs_attempts_api_enabled` set to true. [This idp PR](https://github.com/18F/identity-idp/pull/7194) adds a 'Mock IRS' SP with the attempts api enabled for use with this feature.