### PR TITLE
LG-8498 Persist mock_irs_client_id in step_up flow

### DIFF
--- a/app.rb
+++ b/app.rb
@@ -65,7 +65,7 @@ module LoginGov::OidcSinatra
     end
 
     get '/auth/request' do
-      if params[:enable_attempts_api]
+      if params.has_key?(:enable_attempts_api)
         session[:irs] = params[:enable_attempts_api]
       end
       simulate_csp_issue_if_selected(session: session, simulate_csp: params[:simulate_csp])

--- a/app.rb
+++ b/app.rb
@@ -65,6 +65,9 @@ module LoginGov::OidcSinatra
     end
 
     get '/auth/request' do
+      if params[:enable_attempts_api]
+        session[:irs] = params[:enable_attempts_api]
+      end
       simulate_csp_issue_if_selected(session: session, simulate_csp: params[:simulate_csp])
 
       ial = prepare_step_up_flow(session: session, ial: params[:ial], aal: params[:aal])
@@ -72,7 +75,7 @@ module LoginGov::OidcSinatra
       idp_url = authorization_url(
         ial: ial,
         aal: params[:aal],
-        enable_attempts_api: params[:enable_attempts_api],
+        enable_attempts_api: session[:irs],
       )
 
       settings.logger.info("Redirecting to #{idp_url}")
@@ -143,7 +146,6 @@ module LoginGov::OidcSinatra
     def authorization_url(ial:, aal: nil, enable_attempts_api: nil)
       endpoint = openid_configuration[:authorization_endpoint]
       irs_attempts_api_session_id = enable_attempts_api ? random_value : nil
-      session[:irs] = enable_attempts_api
       request_params = {
         client_id: client_id,
         response_type: 'code',

--- a/spec/app_spec.rb
+++ b/spec/app_spec.rb
@@ -173,6 +173,15 @@ RSpec.describe LoginGov::OidcSinatra::OpenidConnectRelyingParty do
         '/aal/3?hspd12=true',
       )
     end
+
+    it 'redirects with an irs_attempts_api sign in link if enable_attempts_api param is true' do
+      get '/auth/request?enable_attempts_api=true'
+
+      expect(last_response).to be_redirect
+      expect(CGI.unescape(last_response.location)).to include(
+        'irs_attempts_api_session_id',
+      )
+    end
   end
 
   context '/auth/result' do
@@ -337,5 +346,17 @@ RSpec.describe LoginGov::OidcSinatra::OpenidConnectRelyingParty do
         expect(last_response.body).to include('123 Main St., Anytown, US 12345')
       end
     end
+
+    it 'redirects with an irs_attempts_api session link if enable_attempts_api param and step_up flow is true' do
+      get '/auth/request?enable_attempts_api=true&ial=step-up'
+      get '/auth/result', code: code
+      get last_response.location
+
+      expect(last_response).to be_redirect
+      expect(CGI.unescape(last_response.location)).to include(
+        'irs_attempts_api_session_id',
+      )
+    end
+
   end
 end


### PR DESCRIPTION
We noticed a bug where the `enable_attempts_api` flag being set to true did not persist when the "Step Up Flow" option was chosen.  This PR moves when the `session[:irs]` is set to allow it to persist.