### PR TITLE
LG-9314 Sample apps should have failure_to_proof URLs

### DIFF
--- a/app.rb
+++ b/app.rb
@@ -115,6 +115,10 @@ module LoginGov::OidcSinatra
       end
     end
 
+    get '/failure_to_proof' do
+      erb :failure_to_proof
+    end
+
     get '/logout' do
       session[:logout_msg] = 'ok'
       session.delete(:userinfo)

--- a/views/failure_to_proof.erb
+++ b/views/failure_to_proof.erb
@@ -1,6 +1,2 @@
-<div class="container py2">
-  <h1>Failure to Proof</h1>
-  <div>
-    <span>We were unable to verify your identity.</span>
-  </div>
-</div>
+<h1>Failure to Proof</h1>
+<div>We were unable to verify your identity.</div>

--- a/views/failure_to_proof.erb
+++ b/views/failure_to_proof.erb
@@ -1,0 +1,6 @@
+<div class="container py2">
+  <h1>Failure to Proof</h1>
+  <div>
+    <span>We were unable to verify your identity.</span>
+  </div>
+</div>


### PR DESCRIPTION
[LG-9314](https://cm-jira.usa.gov/browse/LG-9314)

Create a route and page for failure to proof

<img border="1" width="384" alt="Screen Shot 2023-04-25 at 3 12 16 PM" src="https://user-images.githubusercontent.com/1261794/234379144-56f66c7f-1ffd-4ef6-b843-57c0b0fd88f5.png">

Note: this page will also be added for the [identity-saml-sinatra](https://github.com/18F/identity-saml-sinatra) app