### PR TITLE
Fix options menu on smaller screen widths

### DIFF
--- a/public/assets/css/sign-in.css
+++ b/public/assets/css/sign-in.css
@@ -39,3 +39,11 @@
 .details-popup .usa-select {
   width: 70%;
 }
+
+@media all and (max-width: 63.99em) {
+  .details-popup[open] {
+    width: initial;
+    right: 0;
+    margin: 5px;
+  }
+}


### PR DESCRIPTION
### Relevant Ticket

[LG-9713](https://cm-jira.usa.gov/browse/LG-9713)

### Description of Changes

Update the CSS for the options drop down menu in smaller screen widths to fit the popout menu.

### Related PR

[identity-saml-sinatra PR#125](https://github.com/18F/identity-saml-sinatra/pull/125)

### Screenshots

Before

<img width="973" alt="image" src="https://github.com/18F/identity-oidc-sinatra/assets/2308626/87e44bc9-3f71-4a76-9f1f-f5d6e7ff5743">

After

<img width="973" alt="image" src="https://github.com/18F/identity-oidc-sinatra/assets/2308626/4aa246bf-22cb-4890-9c06-d4a13fa61f2a">
