### PR TITLE
Add z-index to popup options menu

### DIFF
--- a/public/assets/css/sign-in.css
+++ b/public/assets/css/sign-in.css
@@ -34,6 +34,7 @@
   border-radius: 3px;
   padding: 10px;
   box-shadow: 0 0 10px #fff;
+  z-index: 1;
 }
 
 .details-popup .usa-select {


### PR DESCRIPTION
[cm-jira.usa.gov/browse/LG-9904](https://cm-jira.usa.gov/browse/LG-9904)

This change adds a z-index to the popup menu so that it covers page content.

The menu is short enough that it's not an issue currently, but to show it happening, i deleted the hero text (not permanently, just for demo purposes!)

before:
<img width="369" alt="Screen Shot 2023-06-09 at 10 20 54 AM" src="https://github.com/18F/identity-oidc-sinatra/assets/5473830/4e4608f7-0979-44c3-ac7d-3a3e910ea562">

after:
<img width="349" alt="Screen Shot 2023-06-09 at 10 20 36 AM" src="https://github.com/18F/identity-oidc-sinatra/assets/5473830/1f954584-7c88-4c60-b269-a3f3d3e22865">
