### PR TITLE
Default options menu to open and remove unused options

### DIFF
--- a/spec/app_spec.rb
+++ b/spec/app_spec.rb
@@ -89,8 +89,6 @@ RSpec.describe LoginGov::OidcSinatra::OpenidConnectRelyingParty do
 
     context 'user options' do
       it 'adds inherited proofing auth_code URL param to authorization endpoint when selected by user' do
-        auth_code = 'auth_code_selected_by_user'
-
         get '/'
 
         doc = Nokogiri::HTML(last_response.body)
@@ -98,7 +96,7 @@ RSpec.describe LoginGov::OidcSinatra::OpenidConnectRelyingParty do
         auth_uri = URI(login_link[:href])
         auth_uri_params = Rack::Utils.parse_nested_query(auth_uri.query).with_indifferent_access
 
-        expect(auth_uri_params[:inherited_proofing_auth]).to eq(auth_code)
+        expect(auth_uri_params[:inherited_proofing_auth]).to eq(nil)
       end
     end
   end

--- a/spec/app_spec.rb
+++ b/spec/app_spec.rb
@@ -91,7 +91,7 @@ RSpec.describe LoginGov::OidcSinatra::OpenidConnectRelyingParty do
       it 'adds inherited proofing auth_code URL param to authorization endpoint when selected by user' do
         auth_code = 'auth_code_selected_by_user'
 
-        get '/', { ip_auth_option: auth_code }
+        get '/'
 
         doc = Nokogiri::HTML(last_response.body)
         login_link = doc.at("a[href*='#{authorization_endpoint}']")
@@ -173,15 +173,6 @@ RSpec.describe LoginGov::OidcSinatra::OpenidConnectRelyingParty do
         '/aal/2?hspd12=true',
       )
     end
-
-    it 'redirects with an irs_attempts_api sign in link if enable_attempts_api param is true' do
-      get '/auth/request?enable_attempts_api=true'
-
-      expect(last_response).to be_redirect
-      expect(CGI.unescape(last_response.location)).to include(
-        'irs_attempts_api_session_id',
-      )
-    end
   end
 
   context '/auth/result' do
@@ -260,18 +251,6 @@ RSpec.describe LoginGov::OidcSinatra::OpenidConnectRelyingParty do
         href = logout_link[:href]
         expect(href).to start_with(end_session_endpoint)
         expect(href).to include("client_id=#{CGI.escape(client_id)}")
-      end
-
-
-      it 'redirects with an irs_attempts_api session link if enable_attempts_api param and step_up flow is true' do
-        get '/auth/request?enable_attempts_api=true&ial=step-up'
-        get '/auth/result', code: code
-        get last_response.location
-
-        expect(last_response).to be_redirect
-        expect(CGI.unescape(last_response.location)).to include(
-          'irs_attempts_api_session_id',
-        )
       end
     end
   end

--- a/views/index.erb
+++ b/views/index.erb
@@ -94,7 +94,7 @@
               </button>
             </div>
             <div class="clearfix">
-              <details class="details-popup display-inline-block float-right">
+              <details class="details-popup display-inline-block float-right" open>
                 <summary class="float-right">Options</summary>
 
                 <label class="usa-label" for="aal">
@@ -129,21 +129,6 @@
                   <% end %>
                 </select>
 
-                <label class="usa-label" for="ip-auth-option">
-                  Inherited Proofing
-                </label>
-                <select name="ip_auth_option" id="ip-auth-option" class="usa-select">
-                  <% [
-                       ['', 'Disabled'],
-                       ['mocked-auth-code-for-testing', 'Enabled'],
-                       ['mocked-auth-code-for-failure', 'Simulate failure'],
-                     ].each do |value, label| %>
-                    <option value="<%= value %>" <%= 'selected' if ip_auth_option == value %> >
-                      <%= label %>
-                    </option>
-                  <% end %>
-                </select>
-
                 <hr/>
                 <div class="usa-checkbox">
                   <input class="usa-checkbox__input"
@@ -154,17 +139,6 @@
                   />
                   <label class="usa-checkbox__label" for="check-simulate_csp">
                     Simulate CSP Error
-                  </label>
-                </div>
-                <div class="usa-checkbox">
-                  <input class="usa-checkbox__input"
-                         id="check_enable_attempts_api"
-                         type="checkbox"
-                         name="enable_attempts_api"
-                         value="true"
-                    />
-                  <label class="usa-checkbox__label" for="check_enable_attempts_api">
-                    Enable attempts api
                   </label>
                 </div>
               </details>


### PR DESCRIPTION
### Relevant Ticket or Conversation:

[LG-10194](https://cm-jira.usa.gov/browse/LG-10194)

### Description of Changes:

Changes the behavior of the options menu to be open by default. This PR also removes unused `Inherited Proofing` and `Enable attempts api` options.

### PR Checklist:

1. [X] Have you linted and tested your code locally prior to submission?
2. [X] Have you tagged the appropriate dev(s) for review?
3. [X] Have you linked to any relevant tickets or conversations?

### PR Review Standards: 
- Consider using [Conventional Comments](https://conventionalcomments.org/) to ensure that your feedback is clear and actionable.
- Ideally, PRs should be reviewed by at least 2 team members.
- All PRs must be approved before being merged. 
