### PR TITLE
LG-11697 Add a temporary biometric comparison flag

### DIFF
--- a/app.rb
+++ b/app.rb
@@ -156,6 +156,7 @@ module LoginGov::OidcSinatra
         state: random_value,
         nonce: random_value,
         prompt: 'select_account',
+        biometric_comparison_required: ial == 'biometric-comparison-required',
       }.compact.to_query
 
       "#{endpoint}?#{request_params}"
@@ -183,12 +184,12 @@ module LoginGov::OidcSinatra
     end
 
     def scopes_for(ial)
-      case ial.to_i
-      when 0
+      case ial
+      when '0'
         'openid email social_security_number'
-      when 1
+      when '1', nil
         'openid email'
-      when 2
+      when '2', 'biometric-comparison-required'
         'openid email profile social_security_number phone address'
       else
         raise ArgumentError.new("Unexpected IAL: #{ial.inspect}")
@@ -204,6 +205,7 @@ module LoginGov::OidcSinatra
         '' => 'http://idmanagement.gov/ns/assurance/ial/1',
         '1' => 'http://idmanagement.gov/ns/assurance/ial/1',
         '2' => 'http://idmanagement.gov/ns/assurance/ial/2',
+        'biometric-comparison-required' => 'http://idmanagement.gov/ns/assurance/ial/2',
       }[ial]
 
       values << {

--- a/spec/app_spec.rb
+++ b/spec/app_spec.rb
@@ -98,6 +98,9 @@ RSpec.describe LoginGov::OidcSinatra::OpenidConnectRelyingParty do
       expect(last_response.location).to_not include(
         'scope=openid+email+profile+social_security_number+phone+address',
       )
+      expect(last_response.location).to include(
+        'biometric_comparison_required=false',
+      )
     end
 
     it 'redirects to an ial2 signin if the ial is 2' do
@@ -106,6 +109,9 @@ RSpec.describe LoginGov::OidcSinatra::OpenidConnectRelyingParty do
       expect(last_response).to be_redirect
       expect(last_response.location).to include(
         'scope=openid+email+profile+social_security_number+phone+address',
+      )
+      expect(last_response.location).to include(
+        'biometric_comparison_required=false',
       )
     end
 
@@ -118,6 +124,9 @@ RSpec.describe LoginGov::OidcSinatra::OpenidConnectRelyingParty do
       )
       expect(last_response.location).to_not include(
         'scope=openid+email+profile+social_security_number+phone+address',
+      )
+      expect(last_response.location).to include(
+        'biometric_comparison_required=false',
       )
     end
 
@@ -155,6 +164,21 @@ RSpec.describe LoginGov::OidcSinatra::OpenidConnectRelyingParty do
       expect(last_response).to be_redirect
       expect(CGI.unescape(last_response.location)).to include(
         '/aal/2?hspd12=true',
+      )
+    end
+
+    it 'redirects to ial2 with the flag if the ial param is biometric-comparison-required' do
+      get '/auth/request?ial=biometric-comparison-required'
+
+      expect(last_response).to be_redirect
+      expect(CGI.unescape(last_response.location)).to include(
+        '/ial/2',
+      )
+      expect(last_response.location).to include(
+        'scope=openid+email+profile+social_security_number+phone+address',
+      )
+      expect(last_response.location).to include(
+        'biometric_comparison_required=true',
       )
     end
   end

--- a/views/index.erb
+++ b/views/index.erb
@@ -121,7 +121,8 @@
                        ['1', 'Authentication only (default)'],
                        ['2', 'Identity-verified'],
                        ['0', 'IALMax'],
-                       ['step-up', 'Step-up Flow']
+                       ['step-up', 'Step-up Flow'],
+                       ['biometric-comparison-required', 'Biometric Comparison']
                      ].each do |value, label| %>
                     <option value="<%= value %>" <%= 'selected' if ial == value %> >
                       <%= label %>


### PR DESCRIPTION
In order to test the biometric comparison experience on the IdP we want this app to make a request that requires a biometric comparison. The details of exactly what this will look like are still being ironed out.

This commit adds an option to require a biometric comparison which makes a request with a `biometric_comparison_required` value on the authorization URL. This is not how this is intended to work long term but it does let us test the functionality on the IdP.

At this time the behavior is not implemented on the IdP.