### PR TITLE
LG-12152 Add support for sending a VTR param

### DIFF
--- a/config.rb
+++ b/config.rb
@@ -49,6 +49,10 @@ module LoginGov
         @config.fetch('cache_oidc_config')
       end
 
+      def vtr_enabled?
+        @config.fetch('vtr_enabled')
+      end
+
       # @return [OpenSSL::PKey::RSA]
       def sp_private_key
         return @sp_private_key if @sp_private_key
@@ -72,6 +76,7 @@ module LoginGov
           'sp_private_key_path' => ENV['sp_private_key_path'] || './config/demo_sp.key',
           'redact_ssn' => true,
           'cache_oidc_config' => true,
+          'vtr_enabled' => ENV.fetch('VTR_ENABLED', 'false') == 'true',
         }
 
         # EC2 deployment defaults


### PR DESCRIPTION
This commit adds support for requesting auth using a VTR param. This is enables us to test vector of trust work that is ongoing in the IdP. This also allows us to request biometric comparison without the `biometric_comparison_required` query parameter.

This commit introduces a `VTR_ENABLED`. To run the sample app with VTR support you need to start it like this:

```
VTR_ENABLED=true make run
```

Alternatively, you can add `vtr_enabled: true` to `config/application.yml`.