### PR TITLE
LG-12912 Rename `VTR_ENABLED` to `vtr_disabled`

### DIFF
--- a/app.rb
+++ b/app.rb
@@ -199,7 +199,7 @@ module LoginGov::OidcSinatra
     end
 
     def acr_values(ial:, aal:)
-      return if config.vtr_enabled?
+      return unless config.vtr_disabled?
 
       values = []
 
@@ -222,7 +222,7 @@ module LoginGov::OidcSinatra
     end
 
     def vtr_value(ial:, aal:)
-      return unless config.vtr_enabled?
+      return if config.vtr_disabled?
 
       values = ['C1']
 
@@ -241,12 +241,12 @@ module LoginGov::OidcSinatra
     end
 
     def vtm_value
-      return unless config.vtr_enabled?
+      return if config.vtr_disabled?
       'https://developer.login.gov/vot-trust-framework'
     end
 
     def biometric_comparison_required_value(ial)
-      return if config.vtr_enabled?
+      return unless config.vtr_disabled?
       ial == 'biometric-comparison-required'
     end
 

--- a/config.rb
+++ b/config.rb
@@ -49,8 +49,8 @@ module LoginGov
         @config.fetch('cache_oidc_config')
       end
 
-      def vtr_enabled?
-        @config.fetch('vtr_enabled')
+      def vtr_disabled?
+        @config.fetch('vtr_disabled')
       end
 
       # @return [OpenSSL::PKey::RSA]
@@ -76,7 +76,7 @@ module LoginGov
           'sp_private_key_path' => ENV['sp_private_key_path'] || './config/demo_sp.key',
           'redact_ssn' => true,
           'cache_oidc_config' => true,
-          'vtr_enabled' => ENV.fetch('VTR_ENABLED', 'false') == 'true',
+          'vtr_disabled' => ENV.fetch('vtr_disabled', 'false') == 'true',
         }
 
         # EC2 deployment defaults

--- a/spec/app_spec.rb
+++ b/spec/app_spec.rb
@@ -10,11 +10,11 @@ RSpec.describe LoginGov::OidcSinatra::OpenidConnectRelyingParty do
   let(:userinfo_endpoint) { "#{host}/api/openid/userinfo" }
   let(:end_session_endpoint) { "#{host}/openid/logout" }
   let(:client_id) { 'urn:gov:gsa:openidconnect:sp:sinatra' }
-  let(:vtr_enabled) { false }
+  let(:vtr_disabled) { false }
 
   before do
     allow_any_instance_of(LoginGov::OidcSinatra::Config).to receive(:cache_oidc_config?).and_return(false)
-    allow_any_instance_of(LoginGov::OidcSinatra::Config).to receive(:vtr_enabled?).and_return(vtr_enabled)
+    allow_any_instance_of(LoginGov::OidcSinatra::Config).to receive(:vtr_disabled?).and_return(vtr_disabled)
     stub_request(:get, "#{host}/.well-known/openid-configuration").
       to_return(body: {
         authorization_endpoint: authorization_endpoint,
@@ -90,8 +90,8 @@ RSpec.describe LoginGov::OidcSinatra::OpenidConnectRelyingParty do
   end
 
   context '/auth/request' do
-    context 'with acr_values enabled' do
-      let(:vtr_enabled) { false }
+    context 'with vtr disabled' do
+      let(:vtr_disabled) { true }
 
       it 'redirects to an ial1 sign in link if loa param is nil' do
         get '/auth/request'
@@ -210,7 +210,7 @@ RSpec.describe LoginGov::OidcSinatra::OpenidConnectRelyingParty do
     end
 
     context 'with vtr enabled' do
-      let(:vtr_enabled) { true }
+      let(:vtr_disabled) { false }
 
       it 'redirects to a default sign in link if ial param is nil' do
         get '/auth/request'


### PR DESCRIPTION
The use of the VTR param has been authorized by security and is to be enabled in all environments except for prod. This commit renames the `VTR_ENABLED` config value that enabled the VTR param to `vtr_disabled` which does the opposite. This effectively changes the default behavior if no value is specified.

This commit downcases the name to match the style of the other configs.

We will need to correctly set `vtr_disabled=true` in prod and enable VTR support in the IdP in all environments except prod before merging this.