### PR TITLE
Add note to Biometric Comparison that it is disabled in prod

### DIFF
--- a/views/index.erb
+++ b/views/index.erb
@@ -122,7 +122,7 @@
                        ['2', 'Identity-verified'],
                        ['0', 'IALMax'],
                        ['step-up', 'Step-up Flow'],
-                       ['biometric-comparison-required', 'Biometric Comparison']
+                       ['biometric-comparison-required', 'Biometric Comparison (Disabled in prod)']
                      ].each do |value, label| %>
                     <option value="<%= value %>" <%= 'selected' if ial == value %> >
                       <%= label %>


### PR DESCRIPTION
The biometric comparison feature has been enabled in all environments except for prod. We want to ensure that no partners see it enabled in int and try to use it in their apps which will not work when they are promoted in prod. This commit helps with that by adding a warning label to the "Biometric comparison" option on this sample app.