### PR TITLE
LG-12858 - Add new vtr option (enhanced ipp)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -6,3 +6,4 @@ export sp_private_key_path=./config/demo_sp.key
 # export idp_environment=dev
 export idp_domain=localhost:3000
 export idp_url=http://localhost:3000
+export eipp_allowed=false

--- a/.env.example
+++ b/.env.example
@@ -6,4 +6,3 @@ export sp_private_key_path=./config/demo_sp.key
 # export idp_environment=dev
 export idp_domain=localhost:3000
 export idp_url=http://localhost:3000
-export eipp_allowed=false

--- a/app.rb
+++ b/app.rb
@@ -159,6 +159,7 @@ module LoginGov::OidcSinatra
         nonce: random_value,
         prompt: 'select_account',
         biometric_comparison_required: biometric_comparison_required_value(ial),
+        enhanced_ipp_required: enhanced_ipp_required_value(ial),
       }.compact.to_query
 
       "#{endpoint}?#{request_params}"
@@ -193,6 +194,8 @@ module LoginGov::OidcSinatra
         'openid email x509'
       when '2', 'biometric-comparison-required'
         'openid email profile social_security_number phone address x509'
+      when '2', 'enhanced-ipp-required'
+        'openid email profile social_security_number phone address x509'
       else
         raise ArgumentError.new("Unexpected IAL: #{ial.inspect}")
       end
@@ -210,6 +213,7 @@ module LoginGov::OidcSinatra
         '1' => 'http://idmanagement.gov/ns/assurance/ial/1',
         '2' => 'http://idmanagement.gov/ns/assurance/ial/2',
         'biometric-comparison-required' => 'http://idmanagement.gov/ns/assurance/ial/2',
+        'enhanced-ipp-required' => 'http://idmanagement.gov/ns/assurance/ial/2',
       }[ial]
 
       values << {
@@ -235,6 +239,7 @@ module LoginGov::OidcSinatra
       values << {
         '2' => 'P1',
         'biometric-comparison-required' => 'P1.Pb',
+        'enhanced-ipp-required' => 'P1.Pe',
       }[ial]
 
       vtr_list = [values.compact.join('.')]
@@ -256,6 +261,12 @@ module LoginGov::OidcSinatra
       return unless config.vtr_disabled?
       ial == 'biometric-comparison-required'
     end
+
+    def enhanced_ipp_required_value(ial)
+      return unless config.vtr_disabled?
+      ial == 'enhanced-ipp-required'
+    end
+
 
     def openid_configuration
       if config.cache_oidc_config?

--- a/app.rb
+++ b/app.rb
@@ -155,7 +155,7 @@ module LoginGov::OidcSinatra
         ['biometric-comparison-required', 'Biometric Comparison'],
       ]
 
-      if config.eipp_allowed?
+      if ENV.fetch('eipp_allowed', 'false') == 'true'
         options << [
           'enhanced-ipp-required', 'Enhanced In-Person Proofing (Enabled in staging only)',
         ]

--- a/app.rb
+++ b/app.rb
@@ -280,7 +280,7 @@ module LoginGov::OidcSinatra
     end
 
     def requires_enhanced_ipp?(ial)
-      return unless config.vtr_disabled?
+      return false unless config.vtr_disabled?
       ial == 'enhanced-ipp-required'
     end
 

--- a/app.rb
+++ b/app.rb
@@ -153,7 +153,7 @@ module LoginGov::OidcSinatra
         ['2', 'Identity-verified'],
         ['0', 'IALMax'],
         ['step-up', 'Step-up Flow'],
-        ['biometric-comparison-required', 'Biometric Comparison (Disabled in prod)'],
+        ['biometric-comparison-required', 'Biometric Comparison'],
       ]
       
       if eipp_allowed == 'true'

--- a/app.rb
+++ b/app.rb
@@ -178,7 +178,7 @@ module LoginGov::OidcSinatra
         nonce: random_value,
         prompt: 'select_account',
         biometric_comparison_required: biometric_comparison_required_value(ial),
-        enhanced_ipp_required: enhanced_ipp_required_value(ial),
+        enhanced_ipp_required: requires_enhanced_ipp?(ial),
       }.compact.to_query
 
       "#{endpoint}?#{request_params}"
@@ -279,7 +279,7 @@ module LoginGov::OidcSinatra
       ial == 'biometric-comparison-required'
     end
 
-    def enhanced_ipp_required_value(ial)
+    def requires_enhanced_ipp?(ial)
       return unless config.vtr_disabled?
       ial == 'enhanced-ipp-required'
     end

--- a/app.rb
+++ b/app.rb
@@ -213,9 +213,7 @@ module LoginGov::OidcSinatra
         'openid email social_security_number x509'
       when '1', nil
         'openid email x509'
-      when '2', 'biometric-comparison-required'
-        'openid email profile social_security_number phone address x509'
-      when '2', 'enhanced-ipp-required'
+      when '2', 'biometric-comparison-required', 'enhanced-ipp-required'
         'openid email profile social_security_number phone address x509'
       else
         raise ArgumentError.new("Unexpected IAL: #{ial.inspect}")

--- a/app.rb
+++ b/app.rb
@@ -147,7 +147,6 @@ module LoginGov::OidcSinatra
     private
 
     def get_ial_select_options
-      eipp_allowed = ENV['eipp_allowed']
       options = [
         ['1', 'Authentication only (default)'],
         ['2', 'Identity-verified'],
@@ -155,10 +154,10 @@ module LoginGov::OidcSinatra
         ['step-up', 'Step-up Flow'],
         ['biometric-comparison-required', 'Biometric Comparison'],
       ]
-      
-      if eipp_allowed == 'true'
+
+      if config.eipp_allowed?
         options << [
-          'enhanced-ipp-required', 'Enhanced In-Person Proofing (Enabled in dev & staging only)',
+          'enhanced-ipp-required', 'Enhanced In-Person Proofing (Enabled in staging only)',
         ]
       else
         options

--- a/app.rb
+++ b/app.rb
@@ -148,9 +148,6 @@ module LoginGov::OidcSinatra
 
     def get_ial_select_options
       eipp_allowed = ENV['eipp_allowed']
-      enhanced_ipp_option = [
-        'enhanced-ipp-required', 'Enhanced In-Person Proofing (Enabled in dev & staging only)',
-      ]
       options = [
         ['1', 'Authentication only (default)'],
         ['2', 'Identity-verified'],
@@ -158,12 +155,14 @@ module LoginGov::OidcSinatra
         ['step-up', 'Step-up Flow'],
         ['biometric-comparison-required', 'Biometric Comparison (Disabled in prod)'],
       ]
-
+      
       if eipp_allowed == 'true'
-        options.push(enhanced_ipp_option)
+        options << [
+          'enhanced-ipp-required', 'Enhanced In-Person Proofing (Enabled in dev & staging only)',
+        ]
       else
         options
-      end      
+      end
     end
 
     def authorization_url(ial:, aal: nil)

--- a/app.rb
+++ b/app.rb
@@ -150,7 +150,9 @@ module LoginGov::OidcSinatra
     private
 
     def get_ial_select_options(is_eipp_allowed:)
-      enhanced_ipp_option = ['enhanced-ipp-required', 'Enhanced In-Person Proofing (Enabled in dev & staging only)']
+      enhanced_ipp_option = [
+        'enhanced-ipp-required', 'Enhanced In-Person Proofing (Enabled in dev & staging only)',
+      ]
       option = [
         ['1', 'Authentication only (default)'],
         ['2', 'Identity-verified'],
@@ -292,7 +294,6 @@ module LoginGov::OidcSinatra
       return unless config.vtr_disabled?
       ial == 'enhanced-ipp-required'
     end
-
 
     def openid_configuration
       if config.cache_oidc_config?

--- a/config.rb
+++ b/config.rb
@@ -53,6 +53,10 @@ module LoginGov
         @config.fetch('vtr_disabled')
       end
 
+      def eipp_allowed?
+        @config.fetch('eipp_allowed')
+      end
+
       # @return [OpenSSL::PKey::RSA]
       def sp_private_key
         return @sp_private_key if @sp_private_key
@@ -77,12 +81,17 @@ module LoginGov
           'redact_ssn' => true,
           'cache_oidc_config' => true,
           'vtr_disabled' => ENV.fetch('vtr_disabled', 'false') == 'true',
+          'eipp_allowed' => false,
         }
 
         # EC2 deployment defaults
 
         env = ENV['idp_environment'] || 'int'
         domain = ENV['idp_domain'] || 'identitysandbox.gov'
+
+        if env == 'staging'
+          data['eipp_allowed'] = true
+        end
 
         data['idp_url'] = ENV.fetch('idp_url', nil)
         unless data['idp_url']

--- a/config.rb
+++ b/config.rb
@@ -53,10 +53,6 @@ module LoginGov
         @config.fetch('vtr_disabled')
       end
 
-      def eipp_allowed?
-        @config.fetch('eipp_allowed')
-      end
-
       # @return [OpenSSL::PKey::RSA]
       def sp_private_key
         return @sp_private_key if @sp_private_key
@@ -81,7 +77,7 @@ module LoginGov
           'redact_ssn' => true,
           'cache_oidc_config' => true,
           'vtr_disabled' => ENV.fetch('vtr_disabled', 'false') == 'true',
-          'eipp_allowed' => false,
+          'eipp_allowed' => ENV.fetch('eipp_allowed', 'false') == 'true',
         }
 
         # EC2 deployment defaults

--- a/config.rb
+++ b/config.rb
@@ -89,10 +89,6 @@ module LoginGov
         env = ENV['idp_environment'] || 'int'
         domain = ENV['idp_domain'] || 'identitysandbox.gov'
 
-        if env == 'staging'
-          data['eipp_allowed'] = true
-        end
-
         data['idp_url'] = ENV.fetch('idp_url', nil)
         unless data['idp_url']
           if env == 'prod'

--- a/views/index.erb
+++ b/views/index.erb
@@ -117,14 +117,7 @@
                   Level of Service
                 </label>
                 <select name="ial" id="ial" class="usa-select">
-                  <% [
-                       ['1', 'Authentication only (default)'],
-                       ['2', 'Identity-verified'],
-                       ['0', 'IALMax'],
-                       ['step-up', 'Step-up Flow'],
-                       ['biometric-comparison-required', 'Biometric Comparison'],
-                       ['enhanced-ipp-required', 'Enhanced In-Person Proofing']
-                     ].each do |value, label| %>
+                  <% ial_select_options.each do |value, label| %>
                     <option value="<%= value %>" <%= 'selected' if ial == value %> >
                       <%= label %>
                     </option>

--- a/views/index.erb
+++ b/views/index.erb
@@ -122,7 +122,8 @@
                        ['2', 'Identity-verified'],
                        ['0', 'IALMax'],
                        ['step-up', 'Step-up Flow'],
-                       ['biometric-comparison-required', 'Biometric Comparison']
+                       ['biometric-comparison-required', 'Biometric Comparison'],
+                       ['enhanced-ipp-required', 'Enhanced In-Person Proofing']
                      ].each do |value, label| %>
                     <option value="<%= value %>" <%= 'selected' if ial == value %> >
                       <%= label %>


### PR DESCRIPTION
## 🎫 Ticket

[LG-12858](https://cm-jira.usa.gov/browse/LG-12858)  Implementation: Add new Vector of Trust Option on Sinatra for F&F testing

## 🛠 Summary of changes
+ Set eipp_allowed in staging in oidc-sinatra*
+ Set eipp_allowed to false in all other environments in oidc-sinatra*
        * I think this is achieved. Please see changes in `.env.example` and `config.rb`
+ Added `Enhanced In-Person Proofing` option to the ial (level of service) drop down conditionally (to display in staging only)
+ Mapped new ial (enhanced-ipp-required) to vtr_values P1.Pe  (`P1` : Identity proofing is performed `Pe` :Enhanced proofing)
+ Mapped new ial to arc_value

## 📜 Testing Plan
1. Pull down branch `keithw/LG-13235-consume-eipp-data-from-sinatra` from idp. Open file `app/services/service_provider_request_handler.rb` and add `puts sp_session` on the first line in decorated_sp_session.
2. Start server on branch `keithw/LG-13235-consume-eipp-data-from-sinatra`
3. Pull down this branch locally.
4. Open .env and ensure `eipp_allowed` is set to false
5. Start the server.
6. Visit `http://localhost:9292/`
7. Click on the Level of Service drop down. You should not see `Enhanced In-Person Proofing` as an option.
8. Kill the server.  Change the value of `eipp_allowed` to true. Start the server.
9. Click on the Level of Service drop down. You should see `Enhanced In-Person Proofing` as an option now.
10. Change the Level of Service drop down to `Enhanced In-Person Proofing` and click sign in. 
11. You should be taken to Login locally
12. Inspect the identity-oidc-sinatra terminal. You should see the vtr (vector of trust contains value `C1.P1.Pe` (Pe= enhanced proofing) and that the ial is set to `enhanced-ipp-required`
13. Inspect the identity-idp terminal for the log you set up in testing plan 1. You should see that vrt is added to the session (that is Keith's PR) and that ["C1.P1.Pe"] is set (look at last line of log).
14. Visit `http://localhost:9292/` again.
15. Confirm we are not changing existing behavior. Pick other options in the Level of Service drop down.  Ensure that you are not seeing  `C1.P1.Pe` value be passed in when `Enhanced In-Person Proofing`  is not selected (ie you should see Pb for biometrics rather than Pe) and that the ial set is not `enhanced-ipp-required`.  (Step 12 and 13)

## 📷 Screenshots of env variable set in Cloud.gov [env]-identity-oidc-sinatra
<img width="497" alt="Screenshot 2024-05-31 at 9 53 07 AM" src="https://github.com/18F/identity-oidc-sinatra/assets/125507397/b6a1cc29-2f6d-4e79-82a6-a4eba6b55449">

<img width="502" alt="Screenshot 2024-05-31 at 9 52 51 AM" src="https://github.com/18F/identity-oidc-sinatra/assets/125507397/fe3c066b-8b9a-4abe-8c51-ae99396435ff">

<img width="589" alt="Screenshot 2024-05-31 at 9 51 45 AM" src="https://github.com/18F/identity-oidc-sinatra/assets/125507397/f1d82ca6-a153-4f2a-ba4a-1d435275d26e">

<img width="526" alt="Screenshot 2024-05-31 at 9 51 17 AM" src="https://github.com/18F/identity-oidc-sinatra/assets/125507397/a7bf094d-99c3-4818-926a-5cade1964784">




