### PR TITLE
Add support for IALMax using multiple vectors of trust

### DIFF
--- a/app.rb
+++ b/app.rb
@@ -237,7 +237,14 @@ module LoginGov::OidcSinatra
         'biometric-comparison-required' => 'P1.Pb',
       }[ial]
 
-      [values.compact.join('.')].to_json
+      vtr_list = [values.compact.join('.')]
+
+      if ial == '0'
+        proofing_vector = values.dup + ['P1']
+        vtr_list = [proofing_vector.compact.join('.'), *vtr_list]
+      end
+
+      vtr_list.to_json
     end
 
     def vtm_value

--- a/spec/app_spec.rb
+++ b/spec/app_spec.rb
@@ -248,14 +248,14 @@ RSpec.describe LoginGov::OidcSinatra::OpenidConnectRelyingParty do
         expect(CGI.unescape(last_response.location)).to include('vtr=["C1"]')
       end
 
-      xit 'redirects to an ialmax sign in link if ial param is 0' do
+      it 'redirects to an ialmax sign in link if ial param is 0' do
         get '/auth/request?ial=0'
 
         expect(last_response).to be_redirect
         expect(last_response.location).to include(
           'scope=openid+email+social_security_number',
         )
-        expect(CGI.unescape(last_response.location)).to include('vtr=["C1.P1"]')
+        expect(CGI.unescape(last_response.location)).to include('vtr=["C1.P1","C1"]')
       end
 
       it 'redirects to a default sign in link if ial param is step-up' do


### PR DESCRIPTION
Support for multiple vectors for IALMax is added to the IdP in https://github.com/18F/identity-idp/pull/10517. With that change we can have IALMax-like support with vectors of trust by sending the `C1.P1,C1` vector. This commit adds that to this app.