### PR TITLE
Remove the "Disabled in Prod" label from biometric comparison.

### DIFF
--- a/views/index.erb
+++ b/views/index.erb
@@ -122,7 +122,7 @@
                        ['2', 'Identity-verified'],
                        ['0', 'IALMax'],
                        ['step-up', 'Step-up Flow'],
-                       ['biometric-comparison-required', 'Biometric Comparison (Disabled in prod)']
+                       ['biometric-comparison-required', 'Biometric Comparison']
                      ].each do |value, label| %>
                     <option value="<%= value %>" <%= 'selected' if ial == value %> >
                       <%= label %>


### PR DESCRIPTION
Soon this feature will be enabled in prod and this label will be a lie.