### PR TITLE
Add support for the new `locale` scope to the requested scopes list

### DIFF
--- a/app.rb
+++ b/app.rb
@@ -70,6 +70,7 @@ module LoginGov::OidcSinatra
           sub
           email
           all_emails
+          locale
           ial
           aal
           given_name


### PR DESCRIPTION
In #11754 we are adding support for a new `locale` scope that returns the locale the user was using on Login.gov. This commit enables this app to request that scope using OIDC.


This repo has been moved! Please [open a merge request on GitLab](https://gitlab.login.gov/lg/identity-oidc-sinatra/-/merge_requests/new)
