### PR TITLE
Add profile to available scopes

### DIFF
--- a/app.rb
+++ b/app.rb
@@ -78,6 +78,7 @@ module LoginGov::OidcSinatra
           locale
           ial
           aal
+          profile
           given_name
           family_name
           address


### PR DESCRIPTION
The profile attribute is required in order to request other attributes, such as first name, last name, and date of birth. Without it, checking the name attributes on the sample app's sign in screen would result in them not being sent back to the SP.


This repo has been moved! Please [open a merge request on GitLab](https://gitlab.login.gov/lg/identity-oidc-sinatra/-/merge_requests/new)
